### PR TITLE
feat(converter): new transform style

### DIFF
--- a/speckle_connector/converter/to_native.rb
+++ b/speckle_connector/converter/to_native.rb
@@ -111,8 +111,10 @@ module SpeckleSystems::SpeckleConnector::ToNative
     is_group = false
 
     definition = component_definition_to_native(block["blockDefinition"])
-
-    transform = transform_to_native(block["transform"], block["units"])
+    transform = transform_to_native(
+      block["transform"].is_a?(Hash) ? block["transform"]["value"] : block["transform"],
+      block["units"]
+    )
     instance =
       if is_group
         entities.add_group(definition.entities.to_a)

--- a/speckle_connector/converter/to_speckle.rb
+++ b/speckle_connector/converter/to_speckle.rb
@@ -79,24 +79,28 @@ module SpeckleSystems::SpeckleConnector::ToSpeckle
 
   def transform_to_speckle(transform)
     t_arr = transform.to_a
-    [
-      t_arr[0],
-      t_arr[4],
-      t_arr[8],
-      length_to_speckle(t_arr[12]),
-      t_arr[1],
-      t_arr[5],
-      t_arr[9],
-      length_to_speckle(t_arr[13]),
-      t_arr[2],
-      t_arr[6],
-      t_arr[10],
-      length_to_speckle(t_arr[14]),
-      t_arr[3],
-      t_arr[7],
-      t_arr[11],
-      t_arr[15]
-    ]
+    {
+      speckle_type: "Objects.Other.Transform",
+      units: @units,
+      value: [
+        t_arr[0],
+        t_arr[4],
+        t_arr[8],
+        length_to_speckle(t_arr[12]),
+        t_arr[1],
+        t_arr[5],
+        t_arr[9],
+        length_to_speckle(t_arr[13]),
+        t_arr[2],
+        t_arr[6],
+        t_arr[10],
+        length_to_speckle(t_arr[14]),
+        t_arr[3],
+        t_arr[7],
+        t_arr[11],
+        t_arr[15]
+      ]
+    }
   end
 
   def initialise_group_mesh(face, bounds)


### PR DESCRIPTION
Updates `to_speckle` to create `Objects.Other.Transform` objects when sending `BlockInstances`.

On `to_native`, blocks of both the old and new style transforms will be received as expected!

closes #20 