### PR TITLE
fix(accounts): manually grab user dir

### DIFF
--- a/speckle_connector/accounts.rb
+++ b/speckle_connector/accounts.rb
@@ -34,7 +34,8 @@ module SpeckleSystems::SpeckleConnector
     def self._get_speckle_dir
       speckle_dir =
         case Sketchup.platform
-        when :platform_win then File.join(Dir.home, "AppData/Roaming/Speckle")
+        # sometimes Dir.home on windows points somewhere else bc I guess it's picking up a higher level user?
+        when :platform_win then File.join(Dir.pwd[%r{^((?:[^/]*/){3})}], "AppData/Roaming/Speckle")
         when :platform_osx then File.join(Dir.home, ".config", "Speckle")
         else
           nil


### PR DESCRIPTION
issue with i assume company managed computers where the "current user"
is pointing to somewhere else (maybe the admin who installed sketchup?)

to solve, I'm manually grabbing the user dir from the pwd

closes Auth error and no streams found #27