### PR TITLE
📝 Feat(Attributes): Store face soften property

### DIFF
--- a/speckle_connector/src/speckle_objects/geometry/bounding_box.rb
+++ b/speckle_connector/src/speckle_objects/geometry/bounding_box.rb
@@ -18,7 +18,8 @@ module SpeckleConnector
           xSize: Primitive::Interval,
           ySize: Primitive::Interval,
           zSize: Primitive::Interval,
-          basePlane: Geometry::Plane
+          basePlane: Geometry::Plane,
+          sketchup_attributes: Object
         }.freeze
 
         # @param bounds [Geom::BoundingBox] bounding box object of Sketchup.

--- a/speckle_connector/src/speckle_objects/geometry/line.rb
+++ b/speckle_connector/src/speckle_objects/geometry/line.rb
@@ -19,7 +19,8 @@ module SpeckleConnector
           start: Geometry::Point,
           end: Geometry::Point,
           domain: Primitive::Interval,
-          bbox: Geometry::BoundingBox
+          bbox: Geometry::BoundingBox,
+          sketchup_attributes: Object
         }.freeze
 
         # @param edge [Sketchup::Edge] edge to convert line.

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -19,7 +19,8 @@ module SpeckleConnector
           bbox: Geometry::BoundingBox,
           '@(31250)vertices': Array,
           '@(62500)faces': Array,
-          '@(31250)faceEdgeFlags': Array
+          '@(31250)faceEdgeFlags': Array,
+          sketchup_attributes: Object
         }.freeze
 
         def self.to_native(sketchup_model, mesh, entities)

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -9,8 +9,6 @@ module SpeckleConnector
   module SpeckleObjects
     # Geometry objects in the Speckleverse.
     module Geometry
-      include Converters::CleanUp
-
       # Mesh object definition for Speckle.
       class Mesh < Typescript::TypescriptObject
         SPECKLE_TYPE = 'Objects.Geometry.Mesh'
@@ -41,6 +39,7 @@ module SpeckleConnector
           material = Other::RenderMaterial.to_native(sketchup_model, mesh['renderMaterial'])
           entities.add_faces_from_mesh(native_mesh, 4, material)
           merge_coplanar_faces(entities)
+          Converters::CleanUp.merge_coplanar_faces(entities)
           native_mesh
         end
 

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -25,7 +25,7 @@ module SpeckleConnector
 
         # rubocop:disable Metrics/AbcSize
         def self.to_native(sketchup_model, mesh, entities)
-          is_soften = mesh['sketchup_attributes']['is_soften'].nil? ? true : mesh['su_attributes']['is_soften']
+          is_soften = mesh['sketchup_attributes']['is_soften'].nil? ? true : mesh['sketchup_attributes']['is_soften']
           native_mesh = Geom::PolygonMesh.new(mesh['vertices'].count / 3)
           points = []
           mesh['vertices'].each_slice(3) do |pt|

--- a/speckle_connector/src/speckle_objects/geometry/plane.rb
+++ b/speckle_connector/src/speckle_objects/geometry/plane.rb
@@ -16,7 +16,8 @@ module SpeckleConnector
           xdir: Geometry::Vector,
           ydir: Geometry::Vector,
           normal: Geometry::Vector,
-          origin: Geometry::Point
+          origin: Geometry::Point,
+          sketchup_attributes: Object
         }.freeze
 
         # @param x_dir [Geometry::Vector] vector on the x direction

--- a/speckle_connector/src/speckle_objects/geometry/point.rb
+++ b/speckle_connector/src/speckle_objects/geometry/point.rb
@@ -14,7 +14,8 @@ module SpeckleConnector
           units: String,
           x: Numeric,
           y: Numeric,
-          z: Numeric
+          z: Numeric,
+          sketchup_attributes: Object
         }.freeze
 
         def self.from_coordinates(x, y, z, units)

--- a/speckle_connector/src/speckle_objects/geometry/vector.rb
+++ b/speckle_connector/src/speckle_objects/geometry/vector.rb
@@ -13,7 +13,8 @@ module SpeckleConnector
           units: String,
           x: Numeric,
           y: Numeric,
-          z: Numeric
+          z: Numeric,
+          sketchup_attributes: Object
         }.freeze
 
         def self.from_coordinates(x, y, z, units)

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -19,7 +19,8 @@ module SpeckleConnector
           applicationId: String,
           name: String,
           basePoint: Geometry::Point,
-          '@geometry': Array
+          '@geometry': Array,
+          sketchup_attributes: Object
         }.freeze
 
         # @param definition [Sketchup::ComponentDefinition] component definition might be belong to group or component

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -21,7 +21,8 @@ module SpeckleConnector
           name: [String, NilClass],
           renderMaterial: [Other::RenderMaterial, NilClass],
           transform: Other::Transform,
-          '@blockDefinition': Other::BlockDefinition
+          '@blockDefinition': Other::BlockDefinition,
+          sketchup_attributes: Object
         }.freeze
 
         # @param group [Sketchup::Group] group to convert Speckle BlockInstance

--- a/speckle_connector/src/speckle_objects/other/render_material.rb
+++ b/speckle_connector/src/speckle_objects/other/render_material.rb
@@ -15,7 +15,8 @@ module SpeckleConnector
           opacity: Numeric,
           emissive: Numeric,
           metalness: Numeric,
-          roughness: Numeric
+          roughness: Numeric,
+          sketchup_attributes: Object
         }.freeze
 
         def self.from_material(material)

--- a/speckle_connector/src/speckle_objects/other/transform.rb
+++ b/speckle_connector/src/speckle_objects/other/transform.rb
@@ -11,7 +11,8 @@ module SpeckleConnector
         ATTRIBUTE_TYPES = {
           speckle_type: String,
           units: String,
-          value: Array
+          value: Array,
+          sketchup_attributes: Object
         }.freeze
 
         def self.from_transformation(transformation, units)


### PR DESCRIPTION
Soften edge properties of Face stored into `sketchup_attributes` to be able to create correct faces back&forth.

- [x] Add `sketchup_attributes` object to all speckle objects. This will be the way transfer data.
- [x] When sending faces to server as `SpeckleObjects::Geometry::Mesh`, send `is_soften` flag with `sketchup_attributes`
- [x] When receiving meshes from server, check `is_soften` is set, if not assume that it's true else use value