### PR TITLE
Feat (Stream): Create stream by UI

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -82,6 +82,8 @@
         </v-menu>
       </v-app-bar>
 
+      <CreateStream/>
+
       <v-container fluid>
         <router-view :stream-search-query="streamSearchQuery" />
       </v-container>
@@ -95,6 +97,7 @@
 import { bus } from './main'
 import userQuery from './graphql/user.gql'
 import { onLogin } from './vue-apollo'
+import CreateStream from "@/components/CreateStream";
 
 global.loadAccounts = function (accounts) {
   console.log('>>> SpeckleSketchup: Loading accounts', accounts)
@@ -118,16 +121,22 @@ global.setSelectedAccount = function (account) {
 export default {
   name: 'App',
   components: {
+    CreateStream,
     GlobalToast: () => import('@/components/GlobalToast')
   },
   props: {
     size: {
       type: Number,
       default: 42
-    }
+    },
   },
   data() {
-    return { streamSearchQuery: null }
+    return {
+      streamSearchQuery: null,
+      createNewStreamDialog: false,
+      createStreamByIdDialog: false,
+      createStreamByIdText: ""
+    }
   },
   computed: {
     loggedIn() {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -82,7 +82,7 @@
         </v-menu>
       </v-app-bar>
 
-      <CreateStream/>
+      <create-stream/>
 
       <v-container fluid>
         <router-view :stream-search-query="streamSearchQuery" />
@@ -121,7 +121,7 @@ global.setSelectedAccount = function (account) {
 export default {
   name: 'App',
   components: {
-    CreateStream,
+    CreateStream: () => import('@/components/CreateStream'),
     GlobalToast: () => import('@/components/GlobalToast')
   },
   props: {

--- a/ui/src/components/CreateStream.vue
+++ b/ui/src/components/CreateStream.vue
@@ -92,6 +92,7 @@
         </v-dialog>
 
         <!-- DIALOG: Add a Stream by ID or URL -->
+        <!--
         <v-dialog v-model="showCreateStreamById">
           <template #activator="{ on, attrs }">
             <v-btn
@@ -147,6 +148,7 @@
             </v-card-actions>
           </v-card>
         </v-dialog>
+        -->
       </v-col>
     </v-row>
   </v-container>

--- a/ui/src/components/CreateStream.vue
+++ b/ui/src/components/CreateStream.vue
@@ -157,6 +157,8 @@
 <script>
 /*global sketchup*/
 import gql from "graphql-tag";
+import {bus} from "@/main";
+import userQuery from "@/graphql/user.gql";
 
 export default {
   name: "CreateStream",
@@ -180,12 +182,21 @@ export default {
       return JSON.parse(localStorage.getItem('localAccounts'))
     },
   },
+  apollo: {
+    user: {
+      query: userQuery
+    }
+  },
   methods: {
     activeAccount(){
       return JSON.parse(localStorage.getItem('selectedAccount'))
     },
     switchAccountToCreateStream(account) {
       this.accountToCreateStream = account
+    },
+    refresh() {
+      this.$apollo.queries.user.refetch()
+      bus.$emit('refresh-streams')
     },
     async createStream(){
       let res = await this.$apollo.mutate({
@@ -206,6 +217,7 @@ export default {
       this.streamName = ""
       this.description = ""
       sketchup.exec({name: "save_stream", data: {stream_id: res["data"]["streamCreate"]}})
+      this.refresh()
       return res
     }
   }

--- a/ui/src/components/CreateStream.vue
+++ b/ui/src/components/CreateStream.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-container fluid class="px-1 pb-0 pt-1">
+    <v-dialog
+        v-model="createNewStreamDialog"
+        max-width="390"
+    >
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+            class="ma-2"
+            small
+            v-bind="attrs"
+            v-on="on"
+        >
+          <v-icon
+              dark
+              left
+          >
+            mdi-plus-circle
+          </v-icon>Create New Stream
+        </v-btn>
+      </template>
+
+      <v-card>
+        <v-card-title class="text-h5">
+          Create a New Stream
+        </v-card-title>
+        <v-card-text>
+          Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+              color="blue darken-1"
+              text
+              @click="createNewStreamDialog = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+              color="blue darken-1"
+              text
+              @click="createNewStreamDialog = false"
+          >
+            Create
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-dialog
+        v-model="createStreamByIdDialog"
+        max-width="390"
+    >
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+            class="ma-2"
+            min-width="185"
+            small
+            v-bind="attrs"
+            v-on="on"
+        >
+          <v-icon
+              dark
+              left
+          >
+            mdi-link-plus
+          </v-icon>Add By ID or URL
+        </v-btn>
+      </template>
+
+      <v-card>
+        <v-card-title class="text-h5">
+          Create a New Stream
+        </v-card-title>
+        <v-card-text>
+          Stream IDs and Stream/Branch/Commit URLs are supported.
+        </v-card-text>
+        <v-container>
+          <v-text-field
+              v-model="createStreamByIdText"
+              xxxclass="small-text-field"
+              hide-details
+              dense
+              flat
+              placeholder="Stream URL"
+          />
+        </v-container>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+              color="blue darken-1"
+              text
+              @click="createStreamByIdDialog = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+              :disabled="{createStreamByIdText}"
+              color="blue darken-1"
+              text
+              @click="createStreamByIdDialog = false"
+          >
+            Add
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script>
+
+
+
+export default {
+  name: "CreateStream",
+  data() {
+    return {
+      createNewStreamDialog: false,
+      createStreamByIdDialog: false,
+      createStreamByIdText: ""
+    }
+  },
+}
+</script>

--- a/ui/src/components/CreateStream.vue
+++ b/ui/src/components/CreateStream.vue
@@ -1,124 +1,226 @@
 <template>
   <v-container fluid class="px-1 pb-0 pt-1">
-    <v-dialog
-        v-model="createNewStreamDialog"
-        max-width="390"
-    >
-      <template v-slot:activator="{ on, attrs }">
-        <v-btn
-            class="ma-2"
-            small
-            v-bind="attrs"
-            v-on="on"
-        >
-          <v-icon
-              dark
-              left
-          >
-            mdi-plus-circle
-          </v-icon>Create New Stream
-        </v-btn>
-      </template>
+    <v-row>
+      <v-col>
+        <!-- DIALOG: Create New Stream -->
+        <v-dialog v-model="showCreateNewStream">
+          <template #activator="{ on, attrs }">
+            <v-btn
+                class="ma-2 pa-3"
+                x-small
+                v-bind="attrs"
+                v-on="on"
+            >
+              <v-icon
+                  dark
+                  left
+              >
+                mdi-plus-circle
+              </v-icon>Create New Stream
+            </v-btn>
+          </template>
 
-      <v-card>
-        <v-card-title class="text-h5">
-          Create a New Stream
-        </v-card-title>
-        <v-card-text>
-          Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn
-              color="blue darken-1"
-              text
-              @click="createNewStreamDialog = false"
-          >
-            Cancel
-          </v-btn>
-          <v-btn
-              color="blue darken-1"
-              text
-              @click="createNewStreamDialog = false"
-          >
-            Create
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-    <v-dialog
-        v-model="createStreamByIdDialog"
-        max-width="390"
-    >
-      <template v-slot:activator="{ on, attrs }">
-        <v-btn
-            class="ma-2"
-            min-width="185"
-            small
-            v-bind="attrs"
-            v-on="on"
-        >
-          <v-icon
-              dark
-              left
-          >
-            mdi-link-plus
-          </v-icon>Add By ID or URL
-        </v-btn>
-      </template>
+          <v-card>
+            <v-card-title class="text-h5">
+              Create a New Stream
+            </v-card-title>
+            <v-container class="px-6" pb-0>
+              <!--
+              <v-menu offset-y class="pb-3">
+                <template #activator="{ on, attrs }">
+                  <v-chip v-if="accounts" small v-bind="attrs" v-on="on">
+                    <v-icon small class="mr-1 float-left">mdi-account</v-icon>
+                    {{ accountToCreateStream === null ?
+                      activeAccount().userInfo.email + activeAccount().serverInfo.url:
+                      accountToCreateStream.userInfo.email + accountToCreateStream.serverInfo.url }}
+                  </v-chip>
+                </template>
+                <v-list dense>
+                  <v-list-item
+                      v-for="(account, index) in accounts"
+                      :key="index"
+                      link
+                      @click="switchAccountToCreateStream(account)"
+                  >
+                    <v-list-item-title class="text-caption font-weight-regular">
+                      {{ account.userInfo.email }} ({{ account.serverInfo.url }})
+                    </v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
+              -->
+              <v-text-field
+                  v-model="streamName"
+                  xxxclass="small-text-field"
+                  hide-details
+                  dense
+                  flat
+                  placeholder="Stream Name (Optional)"
+              />
+              <v-text-field
+                  v-model="description"
+                  xxxclass="small-text-field"
+                  hide-details
+                  dense
+                  flat
+                  placeholder="Description (Optional)"
+              />
+              <v-switch
+                  v-model="privateStream"
+                  :label="'Private Stream'"
+              ></v-switch>
+            </v-container>
 
-      <v-card>
-        <v-card-title class="text-h5">
-          Create a New Stream
-        </v-card-title>
-        <v-card-text>
-          Stream IDs and Stream/Branch/Commit URLs are supported.
-        </v-card-text>
-        <v-container>
-          <v-text-field
-              v-model="createStreamByIdText"
-              xxxclass="small-text-field"
-              hide-details
-              dense
-              flat
-              placeholder="Stream URL"
-          />
-        </v-container>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn
-              color="blue darken-1"
-              text
-              @click="createStreamByIdDialog = false"
-          >
-            Cancel
-          </v-btn>
-          <v-btn
-              :disabled="{createStreamByIdText}"
-              color="blue darken-1"
-              text
-              @click="createStreamByIdDialog = false"
-          >
-            Add
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn
+                  color="blue darken-1"
+                  text
+                  @click="showCreateNewStream = false"
+              >
+                Cancel
+              </v-btn>
+              <v-btn
+                  color="blue darken-1"
+                  text
+                  @click="createStream"
+              >
+                Create
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
+
+        <!-- DIALOG: Add a Stream by ID or URL -->
+        <v-dialog v-model="showCreateStreamById">
+          <template #activator="{ on, attrs }">
+            <v-btn
+                class="ma-2 pa-3"
+                x-small
+                min-width="163"
+                v-bind="attrs"
+                v-on="on"
+            >
+              <v-icon
+                  dark
+                  left
+              >
+                mdi-link-plus
+              </v-icon>Add By ID or URL
+            </v-btn>
+          </template>
+
+          <v-card>
+            <v-card-title class="text-h5">
+              Add a Stream by ID or URL
+            </v-card-title>
+            <v-card-text>
+              Stream IDs and Stream/Branch/Commit URLs are supported.
+            </v-card-text>
+            <v-container class="px-6">
+              <v-text-field
+                  v-model="createStreamByIdText"
+                  xxxclass="small-text-field"
+                  hide-details
+                  dense
+                  flat
+                  placeholder="Stream URL"
+              />
+            </v-container>
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn
+                  color="blue darken-1"
+                  text
+                  @click="showCreateStreamById = false"
+              >
+                Cancel
+              </v-btn>
+              <v-btn
+                  :disabled="createStreamByIdText === ''"
+                  color="blue darken-1"
+                  text
+                  @click="showCreateStreamById = false"
+              >
+                Add
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
 <script>
-
-
+/*global sketchup*/
+import gql from "graphql-tag";
 
 export default {
   name: "CreateStream",
   data() {
     return {
-      createNewStreamDialog: false,
-      createStreamByIdDialog: false,
-      createStreamByIdText: ""
+      showCreateNewStream: false,
+      showCreateStreamById: false,
+      createStreamByIdText: "",
+      privateStream: false,
+      streamName: "",
+      description: "",
+      defaultDescription: "Stream created from SketchUp",
+      accountToCreateStream: null
     }
   },
+  computed: {
+    loggedIn() {
+      return localStorage.getItem('SpeckleSketchup.AuthToken') !== null
+    },
+    accounts() {
+      return JSON.parse(localStorage.getItem('localAccounts'))
+    },
+  },
+  methods: {
+    activeAccount(){
+      return JSON.parse(localStorage.getItem('selectedAccount'))
+    },
+    switchAccountToCreateStream(account) {
+      this.accountToCreateStream = account
+    },
+    async createStream(){
+      let res = await this.$apollo.mutate({
+        mutation: gql`
+            mutation streamCreate($stream: StreamCreateInput!) {
+              streamCreate(stream: $stream)
+            }
+          `,
+        variables: {
+          stream: {
+            name: this.streamName,
+            description: this.description === '' ? this.defaultDescription : this.description,
+            isPublic: !this.privateStream
+          }
+        }
+      })
+      this.showCreateNewStream = false
+      this.streamName = ""
+      this.description = ""
+      sketchup.exec({name: "save_stream", data: {stream_id: res["data"]["streamCreate"]}})
+      return res
+    }
+  }
 }
 </script>
+
+<style>
+
+.v-dialog {
+  max-width: 390px
+}
+
+.v-text-field >>> input {
+  font-size: 0.9em;
+}
+.v-text-field >>> label {
+  font-size: 0.9em;
+}
+
+</style>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/45078678/206102868-66e4045b-c64e-4914-89b5-69746d5ce394.png)


Note: Currently we have only Streams view, so we can not open stream page in detail, like send/receive settings, manage contributors, recent activity, comments and report. We need to implement routing between pages for view. Because of this implementing Add Stream By ID or URL options does not make sense. When other views implemented this option will be implemented.