### PR TITLE
Fix (type): Do not convert if entity type does not match with supported types

### DIFF
--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -56,8 +56,11 @@ module SpeckleConnector
         if entity.is_a?(Sketchup::ComponentInstance)
           return SpeckleObjects::Other::BlockInstance.from_component_instance(entity, @units, @definitions)
         end
+        if entity.is_a?(Sketchup::ComponentDefinition)
+          return SpeckleObjects::Other::BlockDefinition.from_definition(entity, @units, @definitions, &convert)
+        end
 
-        SpeckleObjects::Other::BlockDefinition.from_definition(entity, @units, @definitions, &convert)
+        nil
       end
 
       # Create layers -> {Hash{Symbol=>Array}} from sketchup model with empty array as hash entry values.


### PR DESCRIPTION
Do not convert if entity type does not match with supported types, like Dimensions