### PR TITLE
Feat (Group): Send meshes separately under the group

### DIFF
--- a/speckle_connector/src/convertors/base_object_serializer.rb
+++ b/speckle_connector/src/convertors/base_object_serializer.rb
@@ -174,7 +174,7 @@ module SpeckleConnector
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Style/OptionalBooleanParamete
+      # rubocop:disable Style/OptionalBooleanParameter
       def traverse_value(value, is_detach = false)
         # 1. Return same value if value is primitive type (string, numeric, boolean)
         return value unless value.is_a?(Hash) || value.is_a?(Array)
@@ -214,7 +214,7 @@ module SpeckleConnector
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Style/OptionalBooleanParamete
+      # rubocop:enable Style/OptionalBooleanParameter
 
       def detach_helper(reference_id)
         @lineage.each do |parent|

--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -54,7 +54,7 @@ module SpeckleConnector
           return SpeckleObjects::Other::BlockInstance.from_group(entity, @units, @definitions, &convert)
         end
         if entity.is_a?(Sketchup::ComponentInstance)
-          return SpeckleObjects::Other::BlockInstance.from_component_instance(entity, @units, @definitions)
+          return SpeckleObjects::Other::BlockInstance.from_component_instance(entity, @units, @definitions, &convert)
         end
         if entity.is_a?(Sketchup::ComponentDefinition)
           return SpeckleObjects::Other::BlockDefinition.from_definition(entity, @units, @definitions, &convert)

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -59,8 +59,8 @@ module SpeckleConnector
           entities.add_faces_from_mesh(native_mesh, smooth_flags, material)
           added_faces = entities.grep(Sketchup::Face).last(native_mesh.polygons.length)
           added_faces.each { |face| face.layer = layer }
-          # Do not merge coplanar faces if they comes from already sketchup.
-          Converters::CleanUp.merge_coplanar_faces(entities) if mesh['sketchup_attributes'].nil?
+          # Merge only added faces in this scope
+          Converters::CleanUp.merge_coplanar_faces(added_faces)
           native_mesh
         end
 

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -57,16 +57,21 @@ module SpeckleConnector
         end
 
         # @param component_instance [Sketchup::ComponentInstance] component instance to convert Speckle BlockInstance
-        def self.from_component_instance(component_instance, units, component_defs)
+        def self.from_component_instance(component_instance, units, component_defs, &convert)
           BlockInstance.new(
             units: units,
             application_id: component_instance.guid,
             is_sketchup_group: false,
             bbox: Geometry::BoundingBox.from_bounds(component_instance.bounds, units),
             name: component_instance.name == '' ? nil : component_instance.name,
-            render_material: component_instance.material.nil? ? nil : RenderMaterial.from_material(group.material),
+            render_material: if component_instance.material.nil?
+                               nil
+                             else
+                               RenderMaterial.from_material(component_instance.material)
+                             end,
             transform: Other::Transform.from_transformation(component_instance.transformation, units),
-            block_definition: BlockDefinition.from_definition(component_instance.definition, units, component_defs)
+            block_definition: BlockDefinition.from_definition(component_instance.definition, units, component_defs,
+                                                              &convert)
           )
         end
 


### PR DESCRIPTION
Group entities send to Speckle separately instead of grouping them according to material. Otherwise we have to deal with similar problem on [self-intersected faces](https://github.com/specklesystems/speckle-sketchup/issues/103). Which there are no ideal solution yet.

Additionaly scoped face cleanup (merge coplanars) implemented. previously it was merging regardlessly they are under the same scope or not. When we receive previously split faces as below, we can receive them as is.

![scoped_face_merge](https://user-images.githubusercontent.com/45078678/207271088-0524007e-dbc3-4817-a811-6e92b33ab25d.png)
