### PR TITLE
Fix (blocks): Remove bbox and base_point from block objects

### DIFF
--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -16,11 +16,10 @@ module SpeckleConnector
         SPECKLE_TYPE = 'Objects.Other.BlockDefinition'
 
         # @param geometry [Object] geometric definition of the block.
-        # @param base_point [Geometry::Point] base point of the block definition.
         # @param name [String] name of the block definition.
         # @param units [String] units of the block definition.
         # @param application_id [String, NilClass] application id of the block definition.
-        def initialize(geometry:, base_point:, name:, units:, application_id: nil)
+        def initialize(geometry:, name:, units:, application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
             total_children_count: 0,
@@ -29,7 +28,6 @@ module SpeckleConnector
           )
           self[:units] = units
           self[:name] = name
-          self[:basePoint] = base_point
           self['@geometry'] = geometry
         end
 
@@ -54,7 +52,6 @@ module SpeckleConnector
           BlockDefinition.new(
             units: units,
             name: definition.name,
-            base_point: Geometry::Point.new(0, 0, 0, units),
             geometry: geometry,
             application_id: guid
           )

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -16,14 +16,13 @@ module SpeckleConnector
         # @param units [String] units of the block instance.
         # @param is_sketchup_group [Boolean] whether is sketchup group or not. Sketchup Groups represented as
         #  block instance on Speckle.
-        # @param bbox [Geometry::BoundingBox] bounding box of the block instance.
         # @param name [String] name of the block instance.
         # @param transform [Other::Transform] transform of the block instance.
         # @param block_definition [Other::BlockDefinition] definition of the block instance.
         # @param sketchup_attributes [Other::BlockDefinition] sketchup attributes of the block instance.
         # @param application_id [String] application id of the block instance.
         # rubocop:disable Metrics/ParameterLists
-        def initialize(units:, is_sketchup_group:, bbox:, name:, render_material:, transform:, block_definition:,
+        def initialize(units:, is_sketchup_group:, name:, render_material:, transform:, block_definition:,
                        sketchup_attributes: {}, application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
@@ -34,7 +33,6 @@ module SpeckleConnector
           self[:units] = units
           self[:name] = name
           self[:is_sketchup_group] = is_sketchup_group
-          self[:bbox] = bbox
           self[:renderMaterial] = render_material
           self[:transform] = transform
           self[:sketchup_attributes] = sketchup_attributes
@@ -48,7 +46,6 @@ module SpeckleConnector
             units: units,
             application_id: group.guid,
             is_sketchup_group: true,
-            bbox: Geometry::BoundingBox.from_bounds(group.bounds, units),
             name: group.name == '' ? nil : group.name,
             render_material: group.material.nil? ? nil : RenderMaterial.from_material(group.material),
             transform: Other::Transform.from_transformation(group.transformation, units),
@@ -62,7 +59,6 @@ module SpeckleConnector
             units: units,
             application_id: component_instance.guid,
             is_sketchup_group: false,
-            bbox: Geometry::BoundingBox.from_bounds(component_instance.bounds, units),
             name: component_instance.name == '' ? nil : component_instance.name,
             render_material: if component_instance.material.nil?
                                nil


### PR DESCRIPTION
Blocks had ugly base points before as below. Removed!

![2023_01_02_16_40_04_Commit_Speckle](https://user-images.githubusercontent.com/45078678/210248787-54a57f08-8639-4a08-8ea5-a5a9d1031108.png)
