### PR TITLE
Fix (UI): closing UI cause state loss

### DIFF
--- a/speckle_connector/src/ui/dialog.rb
+++ b/speckle_connector/src/ui/dialog.rb
@@ -33,7 +33,7 @@ module SpeckleConnector
 
         # reset dialog only if it is marked ready, otherwise
         # add_exec_callback is triggered twice upon first initialization
-        reset_dialog! if @ready
+        reset_dialog!
         html_dialog.show
       end
 
@@ -73,6 +73,9 @@ module SpeckleConnector
       # @return [UI::HtmlDialog] the Sketchup interface to html dialog
       def init_dialog
         dialog = UI::HtmlDialog.new(@dialog_specs)
+        dialog.set_can_close do
+          true
+        end
         File.exist?(@htm_file) ? dialog.set_file(@htm_file) : dialog.set_url('http://localhost:8081')
         # dialog.set_url('http://localhost:8081') # uncomment this line if you want to use your local version of ui
         add_exec_callback(dialog)

--- a/speckle_connector/src/ui/dialog.rb
+++ b/speckle_connector/src/ui/dialog.rb
@@ -29,6 +29,7 @@ module SpeckleConnector
 
       # Show dialog if it's not visible yet
       def show
+        bring_to_front if html_dialog.visible?
         return if html_dialog.visible?
 
         # reset dialog only if it is marked ready, otherwise


### PR DESCRIPTION
This was a regression about dialog states. With new UI dialog, I approaced it with different way, but did not consider resetting dialog. Currently it's fixed. And this fix come with new UX improvement about minimizing and un-minimizing. When user minimized and considered his/her UI closed, when try to reopen UI, it will un-minimized the previously opened UI. 