### PR TITLE
Fix (block): Base point for block definition

### DIFF
--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -166,6 +166,8 @@ module SpeckleConnector
         end
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
       def convert_to_native(obj, layer, model_preferences, entities = sketchup_model.entities)
         convert = method(:convert_to_native)
         unless obj['displayValue'].nil?
@@ -192,6 +194,8 @@ module SpeckleConnector
         puts(e)
         nil
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/MethodLength
 
       # Creates a component definition and instance from a speckle object with a display value
       # rubocop:disable Metrics/PerceivedComplexity

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -166,8 +166,6 @@ module SpeckleConnector
         end
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       def convert_to_native(obj, layer, model_preferences, entities = sketchup_model.entities)
         convert = method(:convert_to_native)
         unless obj['displayValue'].nil?
@@ -194,20 +192,32 @@ module SpeckleConnector
         puts(e)
         nil
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/MethodLength
 
       # Creates a component definition and instance from a speckle object with a display value
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
       def display_value_to_native_component(obj, layer, entities, model_preferences, &convert)
         obj_id = obj['applicationId'].to_s.empty? ? obj['id'] : obj['applicationId']
+
+        block_definition = obj['@blockDefinition'] || obj['blockDefinition']
+
         definition = BLOCK_DEFINITION.to_native(
           sketchup_model,
           obj['displayValue'],
           layer,
           "def::#{obj_id}",
-          obj['@blockDefinition']['always_face_camera'],
+          if block_definition.nil?
+            false
+          else
+            block_definition['always_face_camera'].nil? ? false : block_definition['always_face_camera']
+          end,
           model_preferences,
-          obj['@blockDefinition']['sketchup_attributes'],
+          if block_definition.nil?
+            nil
+          else
+            block_definition['sketchup_attributes'].nil? ? nil : block_definition['sketchup_attributes']
+          end,
           obj_id,
           &convert
         )
@@ -219,6 +229,9 @@ module SpeckleConnector
         instance.name = obj_id
         instance
       end
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/MethodLength
 
       # Takes a component definition and finds and erases the first instance with the matching name
       # (and optionally the applicationId)

--- a/speckle_connector/src/speckle_objects/geometry/point.rb
+++ b/speckle_connector/src/speckle_objects/geometry/point.rb
@@ -28,6 +28,17 @@ module SpeckleConnector
           self[:units] = units
         end
 
+        # Compare this point with other point those are reference to same coordinate.
+        # @param other [SpeckleObjects::Geometry::Point] other point to compare.
+        def ==(other, tolerance: 1e-15)
+          return false if (self[:x] - other[:x]).abs > tolerance
+          return false if (self[:y] - other[:y]).abs > tolerance
+          return false if (self[:z] - other[:z]).abs > tolerance
+          return false if self[:units] != other[:units]
+
+          true
+        end
+
         # @param vertex [Geom::Point3d] sketchup point to convert speckle point.
         # @param units [String] unit of the point.
         def self.from_vertex(vertex, units)

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -35,6 +35,7 @@ module SpeckleConnector
           self[:basePoint] = base_point
           self[:always_face_camera] = always_face_camera
           self[:sketchup_attributes] = sketchup_attributes if sketchup_attributes.any?
+          # FIXME: Since geometry sends with @ as detached, block basePlane renders on viewer.
           self['@geometry'] = geometry
         end
         # rubocop:enable Metrics/ParameterLists

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -22,7 +22,8 @@ module SpeckleConnector
         # @param units [String] units of the block definition.
         # @param application_id [String, NilClass] application id of the block definition.
         # rubocop:disable Metrics/ParameterLists
-        def initialize(geometry:, base_point:, name:, units:, always_face_camera:, sketchup_attributes: {}, application_id: nil)
+        def initialize(geometry:, base_point:, name:, units:, always_face_camera:, sketchup_attributes: {},
+                       application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
             total_children_count: 0,

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -17,11 +17,12 @@ module SpeckleConnector
         SPECKLE_TYPE = 'Objects.Other.BlockDefinition'
 
         # @param geometry [Object] geometric definition of the block.
+        # @param base_point [Geometry::Point] base point of the block definition.
         # @param name [String] name of the block definition.
         # @param units [String] units of the block definition.
         # @param application_id [String, NilClass] application id of the block definition.
         # rubocop:disable Metrics/ParameterLists
-        def initialize(geometry:, name:, units:, always_face_camera:, sketchup_attributes: {}, application_id: nil)
+        def initialize(geometry:, base_point:, name:, units:, always_face_camera:, sketchup_attributes: {}, application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
             total_children_count: 0,
@@ -30,6 +31,7 @@ module SpeckleConnector
           )
           self[:units] = units
           self[:name] = name
+          self[:basePoint] = base_point
           self[:always_face_camera] = always_face_camera
           self[:sketchup_attributes] = sketchup_attributes if sketchup_attributes.any?
           self['@geometry'] = geometry
@@ -66,6 +68,7 @@ module SpeckleConnector
           BlockDefinition.new(
             units: units,
             name: definition.name,
+            base_point: Geometry::Point.new(0, 0, 0, units),
             geometry: geometry,
             always_face_camera: definition.behavior.always_face_camera?,
             sketchup_attributes: att,

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -104,15 +104,16 @@ module SpeckleConnector
           # so this is set to false always until I can figure this out
           is_group = false
           # is_group = block['is_sketchup_group']
+          block_definition = block['@blockDefinition'] || block['blockDefinition']
           definition = BlockDefinition.to_native(
             sketchup_model,
-            block['@blockDefinition']['@geometry'],
+            block_definition['@geometry'],
             layer,
-            block['@blockDefinition']['name'],
-            block['@blockDefinition']['always_face_camera'],
+            block_definition['name'],
+            block_definition['always_face_camera'].nil? ? false : block_definition['always_face_camera'],
             model_preferences,
-            block['@blockDefinition']['sketchup_attributes'],
-            block['@blockDefinition']['applicationId'],
+            block_definition['sketchup_attributes'],
+            block_definition['applicationId'],
             &convert
           )
 

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -105,9 +105,10 @@ module SpeckleConnector
           is_group = false
           # is_group = block['is_sketchup_group']
           block_definition = block['@blockDefinition'] || block['blockDefinition']
+          geometry = block_definition['@geometry'] || block_definition['geometry']
           definition = BlockDefinition.to_native(
             sketchup_model,
-            block_definition['@geometry'],
+            geometry,
             layer,
             block_definition['name'],
             block_definition['always_face_camera'].nil? ? false : block_definition['always_face_camera'],

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -37,6 +37,7 @@ module SpeckleConnector
           self[:renderMaterial] = render_material
           self[:transform] = transform
           self[:sketchup_attributes] = sketchup_attributes if sketchup_attributes.any?
+          # FIXME: Since blockDefinition sends with @ as detached, block basePlane renders on viewer.
           self['@blockDefinition'] = block_definition
         end
         # rubocop:enable Metrics/ParameterLists


### PR DESCRIPTION
Found out that reason to have base point on viewer for each block instance. It is because of handling different traversing objects between sharp connectors and ruby. On ruby everything is dynamic on hash object. For now it is not a blocker for anything. So inline code took notes and fixed some of the problems between Rhino-Sketchup in terms of Block transactions.