### PR TITLE
Feat (Mesh): mesh improvements

### DIFF
--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -145,7 +145,8 @@ module SpeckleConnector
         def face_vertices_to_array(face)
           face.vertices.each do |v|
             pt = v.position
-            vertices.push(pt) unless vertices.any? { |point| point == pt }
+            # vertices.push(pt) unless vertices.any? { |point| point == pt }
+            vertices.push(pt)
           end
         end
 
@@ -154,8 +155,9 @@ module SpeckleConnector
           polygons.push(face.vertices.count)
           face.vertices.each do |v|
             pt = v.position
-            index = vertices.find_index(pt)
-            polygons.push(index)
+            # global_vertex_index = vertices.reverse.find_index(pt)
+            global_vertex_index = vertices.length - vertices.reverse.find_index(pt) - 1
+            polygons.push(global_vertex_index)
           end
         end
 
@@ -163,7 +165,8 @@ module SpeckleConnector
         # @param mesh [Geom::PolygonMesh] mesh to get points.
         def mesh_points_to_array(mesh)
           mesh.points.each do |pt|
-            vertices.push(pt) unless vertices.any? { |point| point == pt }
+            # vertices.push(pt) unless vertices.any? { |point| point == pt }
+            vertices.push(pt)
           end
         end
 
@@ -173,7 +176,8 @@ module SpeckleConnector
           mesh.polygons.each do |poly|
             global_polygon_array = [poly.count]
             poly.each do |index|
-              global_vertex_index = vertices.find_index(mesh.points[index.abs - 1])
+              # global_vertex_index = vertices.reverse.find_index(mesh.points[index.abs - 1])
+              global_vertex_index = vertices.length - vertices.reverse.find_index(mesh.points[index.abs - 1]) - 1
               global_polygon_array.push(global_vertex_index)
             end
             polygons.push(*global_polygon_array)

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -89,8 +89,6 @@ module SpeckleConnector
 
         # @param face [Sketchup::Face] face to convert mesh
         # rubocop:disable Style/MultilineTernaryOperator
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/PerceivedComplexity
         def self.from_face(face, units, model_preferences)
           dictionaries = {}
           if model_preferences[:include_entity_attributes]
@@ -114,8 +112,6 @@ module SpeckleConnector
           speckle_mesh
         end
         # rubocop:enable Style/MultilineTernaryOperator
-        # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/PerceivedComplexity
 
         def face_to_mesh(face)
           mesh = face.loops.count > 1 ? face.mesh : nil

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -145,6 +145,7 @@ module SpeckleConnector
         def face_vertices_to_array(face)
           face.vertices.each do |v|
             pt = v.position
+            # FIXME: Enable previous line when viewer supports shared vertices
             # vertices.push(pt) unless vertices.any? { |point| point == pt }
             vertices.push(pt)
           end
@@ -155,6 +156,7 @@ module SpeckleConnector
           polygons.push(face.vertices.count)
           face.vertices.each do |v|
             pt = v.position
+            # FIXME: Enable previous line when viewer supports shared vertices
             # global_vertex_index = vertices.reverse.find_index(pt)
             global_vertex_index = vertices.length - vertices.reverse.find_index(pt) - 1
             polygons.push(global_vertex_index)
@@ -165,6 +167,7 @@ module SpeckleConnector
         # @param mesh [Geom::PolygonMesh] mesh to get points.
         def mesh_points_to_array(mesh)
           mesh.points.each do |pt|
+            # FIXME: Enable previous line when viewer supports shared vertices
             # vertices.push(pt) unless vertices.any? { |point| point == pt }
             vertices.push(pt)
           end
@@ -176,6 +179,7 @@ module SpeckleConnector
           mesh.polygons.each do |poly|
             global_polygon_array = [poly.count]
             poly.each do |index|
+              # FIXME: Enable previous line when viewer supports shared vertices
               # global_vertex_index = vertices.reverse.find_index(mesh.points[index.abs - 1])
               global_vertex_index = vertices.length - vertices.reverse.find_index(mesh.points[index.abs - 1]) - 1
               global_polygon_array.push(global_vertex_index)

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -136,6 +136,8 @@ module SpeckleConnector
             definition.entities.grep(Sketchup::Face).collect do |face|
               group_meshes_by_material(definition, face, mesh_groups, units, preferences[:model])
             end
+            # Update mesh overwrites points and polygons into base object.
+            mesh_groups.each { |_, mesh| mesh.update_mesh }
 
             lines + nested_blocks + nested_groups + mesh_groups.values
           else
@@ -157,17 +159,7 @@ module SpeckleConnector
           mat_id = get_mesh_group_id(face, model_preferences)
           mat_groups[mat_id] = initialise_group_mesh(face, definition.bounds, units) unless mat_groups.key?(mat_id)
           mat_group = mat_groups[mat_id]
-          if face.loops.size > 1
-            mesh = face.mesh
-            mat_group[:'@(31250)vertices'].push(*Geometry::Mesh.mesh_points_to_array(mesh, units))
-            mat_group[:'@(62500)faces'].push(*Geometry::Mesh.mesh_faces_to_array(mesh, mat_group[:pt_count] - 1))
-            mat_group[:'@(31250)faceEdgeFlags'].push(*Geometry::Mesh.mesh_edge_flags_to_array(mesh))
-          else
-            mat_group[:'@(31250)vertices'].push(*Geometry::Mesh.face_vertices_to_array(face, units))
-            mat_group[:'@(62500)faces'].push(*Geometry::Mesh.face_indices_to_array(face, mat_group[:pt_count]))
-            mat_group[:'@(31250)faceEdgeFlags'].push(*Geometry::Mesh.face_edge_flags_to_array(face))
-          end
-          mat_group[:pt_count] += face.vertices.count
+          mat_group.face_to_mesh(face)
         end
         # rubocop:enable Metrics/AbcSize
 
@@ -179,7 +171,6 @@ module SpeckleConnector
             bbox: Geometry::BoundingBox.from_bounds(bounds, units),
             vertices: [],
             faces: [],
-            face_edge_flags: [],
             sketchup_attributes: { is_soften: has_any_soften_edge }
           )
           mesh[:pt_count] = 0

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -153,7 +153,6 @@ module SpeckleConnector
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/PerceivedComplexity
 
-        # rubocop:disable Metrics/AbcSize
         def self.group_meshes_by_material(definition, face, mat_groups, units, model_preferences)
           # convert material
           mat_id = get_mesh_group_id(face, model_preferences)
@@ -161,7 +160,6 @@ module SpeckleConnector
           mat_group = mat_groups[mat_id]
           mat_group.face_to_mesh(face)
         end
-        # rubocop:enable Metrics/AbcSize
 
         def self.initialise_group_mesh(face, bounds, units)
           has_any_soften_edge = face.edges.any?(&:soft?)


### PR DESCRIPTION
Closes #130

Mesh grouping methods are improved with options:
- Shared vertices (It is not supported by viewer currently, but when available it is ready to approach)
- Separated vertices

These improvements also fixed the bug with group meshes that reported previously by https://speckle.community/t/sketchup-speckle-connector/4360.