### PR TITLE
Chore (Theming): Store light mode setting separately

### DIFF
--- a/speckle_connector/src/preferences/preferences.rb
+++ b/speckle_connector/src/preferences/preferences.rb
@@ -10,6 +10,7 @@ module SpeckleConnector
   module Preferences
     include Immutable::ImmutableUtils
     DICT_HANDLER = SketchupModel::Dictionary::SpeckleModelDictionaryHandler
+    DEFAULT_PREFERENCES = "('configSketchup', '{\"DarkTheme\":false}');"
 
     # @param sketchup_model [Sketchup::Model] active model.
     # rubocop:disable Metrics/MethodLength
@@ -17,8 +18,13 @@ module SpeckleConnector
       # Init sqlite database
       db = Sqlite3::Database.new(SPECKLE_CONFIG_DB_PATH)
 
+      # Check configSketchup key is valid or not, otherwise init with default settings
+      if db.exec("SELECT content FROM 'objects' WHERE hash = 'configSketchup'").empty?
+        db.exec("INSERT INTO 'objects' VALUES #{DEFAULT_PREFERENCES}")
+      end
+
       # Select data
-      data = db.exec("SELECT content FROM 'objects' WHERE hash = 'configDUI'").first.first
+      data = db.exec("SELECT content FROM 'objects' WHERE hash = 'configSketchup'").first.first
 
       # Parse string to hash
       data_hash = JSON.parse(data).to_h

--- a/ui/src/components/SettingsDialog.vue
+++ b/ui/src/components/SettingsDialog.vue
@@ -129,7 +129,7 @@ export default {
       this.$vuetify.theme.dark = !this.$vuetify.theme.dark
       sketchup.exec({
         name: "user_preferences_updated",
-        data: {preference_hash: "configDUI", preference: "DarkTheme", value: this.$vuetify.theme.dark}
+        data: {preference_hash: "configSketchup", preference: "DarkTheme", value: this.$vuetify.theme.dark}
       })
       this.$mixpanel.track('Connector Action', { name: 'Toggle Theme' })
     },


### PR DESCRIPTION
Sketchup user preferences stores separately anymore. It creates also row on database if it is not initialized before or somehow reseted.

![image](https://user-images.githubusercontent.com/45078678/212908080-d948b9aa-38f4-42ea-be69-0900ab7fbce4.png)
