### PR TITLE
Improve refreshMixpanelIds function with better registration

### DIFF
--- a/speckle_connector/src/actions/collect_versions.rb
+++ b/speckle_connector/src/actions/collect_versions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module SpeckleConnector
+  module Actions
+    # Action to collect versions from sketchup and connector to track user's version by mixpanel.
+    class CollectVersions < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, _data)
+        versions = {
+          sketchup: Sketchup.version.to_i,
+          speckle: SpeckleConnector::CONNECTOR_VERSION
+        }
+        state.with_add_queue('collectVersions', versions.to_json, [])
+      end
+    end
+  end
+end

--- a/speckle_connector/src/ui/vue_view.rb
+++ b/speckle_connector/src/ui/vue_view.rb
@@ -18,6 +18,7 @@ require_relative '../actions/reload_accounts'
 require_relative '../actions/load_saved_streams'
 require_relative '../actions/init_local_accounts'
 require_relative '../actions/collect_preferences'
+require_relative '../actions/collect_versions'
 
 module SpeckleConnector
   module Ui
@@ -65,6 +66,7 @@ module SpeckleConnector
           remove_stream: Commands::RemoveStream.new(@app),
           notify_connected: Commands::NotifyConnected.new(@app),
           collect_preferences: Commands::ActionCommand.new(@app, Actions::CollectPreferences),
+          collect_versions: Commands::ActionCommand.new(@app, Actions::CollectVersions),
           user_preferences_updated: Commands::UserPreferencesUpdated.new(@app),
           model_preferences_updated: Commands::ModelPreferencesUpdated.new(@app)
         }.freeze

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -108,13 +108,19 @@ global.collectPreferences = function (preferences) {
   bus.$emit('update-preferences', preferences)
 }
 
+global.collectVersions = function (versions) {
+  let vers = JSON.parse(versions)
+  localStorage.setItem('hostAppVersion', vers.sketchup)
+  localStorage.setItem('speckleVersion', vers.speckle)
+}
+
 global.loadAccounts = function (accounts) {
   console.log('>>> SpeckleSketchup: Loading accounts', accounts)
   localStorage.setItem('localAccounts', JSON.stringify(accounts))
   let uuid = localStorage.getItem('uuid')
   if (accounts.length !== 0){
     if (uuid) {
-      global.setSelectedAccount(accounts.find((acct) => acct['userInfo']['id'] == uuid))
+      global.setSelectedAccount(accounts.find((acct) => acct['userInfo']['id'] === uuid))
     } else {
       global.setSelectedAccount(accounts.find((acct) => acct['isDefault']))
     }
@@ -180,8 +186,13 @@ export default {
       this.$vuetify.theme.dark = this.preferences.user.dark_theme
     })
 
+    // Collect versions to inform mixpanel
+    sketchup.exec({name: "collect_versions", data: {}})
+
+    // Collect preferences to render UI according to it
     sketchup.exec({name: "collect_preferences", data: {}})
-    // this.$vuetify.theme.dark = localStorage.getItem('theme') == 'dark'
+
+    // Collect accounts from 'Accounts.db' by ruby sqlite3
     sketchup.exec({name: "init_local_accounts", data: {}})
   },
   methods: {

--- a/ui/src/plugins/speckle-metrics.js
+++ b/ui/src/plugins/speckle-metrics.js
@@ -10,9 +10,12 @@ const SpeckleMetrics = {
 
     Vue.prototype.$mixpanel = mixpanel
     Vue.prototype.$mixpanel.init(token, config)
-    Vue.prototype.$mixpanel.register({ hostApp: 'sketchup', type: 'action' })
 
     Vue.prototype.$refreshMixpanelIds = function () {
+      // 1. It logs out the user and removes out the registered props.
+      Vue.prototype.$mixpanel.reset()
+
+      // 2. create hashes for user distinction
       let distinctId =
         '@' +
         crypto
@@ -29,12 +32,20 @@ const SpeckleMetrics = {
         .digest('hex')
         .toUpperCase()
 
+      // 3. Setting super properties that will be sent with every event
       Vue.prototype.$mixpanel.register({
-        // eslint-disable-next-line camelcase
-        distinct_id: distinctId,
-        // eslint-disable-next-line camelcase
+        hostApp: 'sketchup',
+        type: 'action',
+        hostAppVersion: localStorage.getItem('hostAppVersion'),
+        core_version: localStorage.getItem('speckleVersion'),
         server_id: serverId
       })
+
+      // 4. Logging into user
+      Vue.prototype.$mixpanel.identify(distinctId)
+
+      // 5. If it is a registered user we can consider it is identified
+      Vue.prototype.$mixpanel.people.set("Identified", true)
     }
   }
 }


### PR DESCRIPTION
Versions of sketchup and speckle connector included into registration.
Also missing identify method added. Thanks to @teocomi 