### PR TITLE
Chore (Query): Query source application from commit

### DIFF
--- a/speckle_connector/src/actions/receive_objects.rb
+++ b/speckle_connector/src/actions/receive_objects.rb
@@ -8,14 +8,17 @@ module SpeckleConnector
   module Actions
     # Action to receive objects from Speckle Server.
     class ReceiveObjects < Action
-      def initialize(stream_id, base, stream_name, branch_name, branch_id)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(stream_id, base, stream_name, branch_name, branch_id, source_app)
         super()
         @stream_id = stream_id
         @base = base
         @stream_name = stream_name
         @branch_name = branch_name
         @branch_id = branch_id
+        @source_app = source_app
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
       # @return [States::State] the new updated state object
@@ -26,6 +29,7 @@ module SpeckleConnector
         converter.receive_commit_object(@base, state.user_state.preferences[:model])
         elapsed_time = (Time.now.to_f - start_time).round(3)
         puts "==== Converting to Native executed in #{elapsed_time} sec ===="
+        puts "==== Source application is #{@source_app}. ===="
         state.with_add_queue('finishedReceiveInSketchup', @stream_id, [])
       end
     end

--- a/speckle_connector/src/commands/receive_objects.rb
+++ b/speckle_connector/src/commands/receive_objects.rb
@@ -13,7 +13,8 @@ module SpeckleConnector
         branch_name = data['branch_name']
         branch_id = data['branch_id']
         stream_name = data['stream_name']
-        action = Actions::ReceiveObjects.new(stream_id, base, stream_name, branch_name, branch_id)
+        source_app = data['source_app']
+        action = Actions::ReceiveObjects.new(stream_id, base, stream_name, branch_name, branch_id, source_app)
         app.update_state!(action)
       end
     end

--- a/ui/src/components/StreamCard.vue
+++ b/ui/src/components/StreamCard.vue
@@ -398,7 +398,8 @@ export default {
           stream_name: this.stream.name,
           stream_id: this.streamId,
           branch_name: this.selectedCommit.branchName,
-          branch_id: this.selectedCommit.id
+          branch_id: this.selectedCommit.id,
+          source_app: this.selectedCommit.sourceApplication
       }})
 
       await this.$apollo.mutate({

--- a/ui/src/graphql/stream.gql
+++ b/ui/src/graphql/stream.gql
@@ -42,6 +42,7 @@ query Stream($id: String!) {
             branchName
             authorName
             authorAvatar
+            sourceApplication
             referencedObject
           }
         }


### PR DESCRIPTION
When streams queried with stream query we also need information for `sourceApplication` to understand referencedObject source. This will help to act different on receive objects for Revit to Sketchup workflow. Another way instead sourceApp, distinguishing objects according to speckle_type. This idea still WIP and this PR good to have in advance.

Closing #179