### PR TITLE
Feat (Layers): revit categories as tags

### DIFF
--- a/speckle_connector/src/actions/receive_objects.rb
+++ b/speckle_connector/src/actions/receive_objects.rb
@@ -23,7 +23,7 @@ module SpeckleConnector
       # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
       # @return [States::State] the new updated state object
       def update_state(state)
-        converter = Converters::ToNative.new(state, @stream_id)
+        converter = Converters::ToNative.new(state, @stream_id, @source_app)
         # Have side effects on the sketchup model. It effects directly on the entities by adding new objects.
         start_time = Time.now.to_f
         state = converter.receive_commit_object(@base)

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -114,6 +114,7 @@ module SpeckleConnector
           Objects.BuiltElements.Ceiling
           Objects.BuiltElements.Column
           Objects.BuiltElements.Beam
+          Objects.BuiltElements.Roof
         ].freeze
 
         def self.get_definition_name(def_obj)


### PR DESCRIPTION
Categories to tags in sketchup. There was some missing layers after receive like Windows and Doors. Now they are OK.

Closes #181 