### PR TITLE
Feat (Instancing): Definition naming convention

### DIFF
--- a/speckle_connector/src/actions/receive_objects.rb
+++ b/speckle_connector/src/actions/receive_objects.rb
@@ -23,7 +23,7 @@ module SpeckleConnector
       # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
       # @return [States::State] the new updated state object
       def update_state(state)
-        converter = Converters::ToNative.new(state, @stream_id, @source_app)
+        converter = Converters::ToNative.new(state, @stream_id, @stream_name, @branch_name, @source_app)
         # Have side effects on the sketchup model. It effects directly on the entities by adding new objects.
         start_time = Time.now.to_f
         state = converter.receive_commit_object(@base)

--- a/speckle_connector/src/convertors/base_object_serializer.rb
+++ b/speckle_connector/src/convertors/base_object_serializer.rb
@@ -352,7 +352,8 @@ module SpeckleConnector
           speckle_state.speckle_entities[entity.persistent_id].with_valid_stream_id(stream_id)
         else
           children = traversed_base[:__closure].nil? ? {} : traversed_base[:__closure]
-          speckle_entity = SpeckleEntities::SpeckleEntity.new(entity, id, traversed_base[:speckle_type],
+          speckle_entity = SpeckleEntities::SpeckleEntity.new(entity, id, entity.persistent_id,
+                                                              traversed_base[:speckle_type],
                                                               children.keys, [stream_id])
           speckle_entity.write_initial_base_data
           speckle_entity

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -368,7 +368,8 @@ module SpeckleConnector
         children = speckle_object['__closure'].nil? ? [] : speckle_object['__closure']
         speckle_state = state.speckle_state
         entities.each do |entity|
-          ent = SpeckleEntities::SpeckleEntity.new(entity, speckle_id, application_id, speckle_type, children, [stream_id])
+          ent = SpeckleEntities::SpeckleEntity.new(entity, speckle_id, application_id, speckle_type, children,
+                                                   [stream_id])
           ent.write_initial_base_data
           speckle_state = speckle_state.with_speckle_entity(ent)
         end

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -75,7 +75,9 @@ module SpeckleConnector
       LAYERS_WILL_BE_HIDDEN = [
         'Rooms',
         'Mass',
-        'Mass Floor'
+        'Mass Floor',
+        'Grid',
+        'Shaft Openings'
       ].freeze
 
       def check_hiding_layers_needed

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -82,8 +82,12 @@ module SpeckleConnector
       def entities_to_fill(_obj)
         return sketchup_model.entities if from_sketchup
 
-        definition = sketchup_model.definitions.add("#{@stream_name}-#{@branch_name}")
-        sketchup_model.entities.add_instance(definition, Geom::Transformation.new)
+        definition_name = "#{@stream_name}-#{@branch_name}"
+        definition = sketchup_model.definitions.find { |d| d.name == definition_name }
+        if definition.nil?
+          definition = sketchup_model.definitions.add(definition_name)
+          sketchup_model.entities.add_instance(definition, Geom::Transformation.new)
+        end
         definition.entities
       end
 
@@ -359,11 +363,12 @@ module SpeckleConnector
         return state unless state.user_state.user_preferences[:register_speckle_entity]
 
         speckle_id = speckle_object['id']
+        application_id = speckle_object['applicationId']
         speckle_type = speckle_object['speckle_type']
         children = speckle_object['__closure'].nil? ? [] : speckle_object['__closure']
         speckle_state = state.speckle_state
         entities.each do |entity|
-          ent = SpeckleEntities::SpeckleEntity.new(entity, speckle_id, speckle_type, children, [stream_id])
+          ent = SpeckleEntities::SpeckleEntity.new(entity, speckle_id, application_id, speckle_type, children, [stream_id])
           ent.write_initial_base_data
           speckle_state = speckle_state.with_speckle_entity(ent)
         end

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -30,11 +30,12 @@ module SpeckleConnector
         def self.read_speckle_entity(entity)
           dict = entity.attribute_dictionaries.to_a.find { |d| d.name == SPECKLE_BASE_OBJECT }
           speckle_id = dict[:speckle_id]
+          application_id = dict[:application_id]
           speckle_type = dict[:speckle_type]
           children = dict[:children]
           valid_stream_ids = dict[:valid_stream_ids]
           invalid_stream_ids = dict[:invalid_stream_ids]
-          SpeckleEntities::SpeckleEntity.new(entity, speckle_id, speckle_type, children,
+          SpeckleEntities::SpeckleEntity.new(entity, speckle_id, application_id, speckle_type, children,
                                              valid_stream_ids, invalid_stream_ids)
         end
 

--- a/speckle_connector/src/speckle_entities/speckle_entity.rb
+++ b/speckle_connector/src/speckle_entities/speckle_entity.rb
@@ -41,14 +41,14 @@ module SpeckleConnector
 
       # @param sketchup_entity [Sketchup::Entity] sketchup entity represents {SpeckleEntity} on the model.
       # rubocop:disable Metrics/ParameterLists
-      def initialize(sketchup_entity, speckle_id, speckle_type, children, valid_stream_ids, invalid_stream_ids = [])
+      def initialize(sketchup_entity, speckle_id, application_id, speckle_type, children, valid_stream_ids, invalid_stream_ids = [])
         @status = SpeckleEntityStatus::UP_TO_DATE
         @source_material = sketchup_entity.material
         @active_diffing_stream_id = nil
         @valid_stream_ids = valid_stream_ids
         @invalid_stream_ids = invalid_stream_ids
         @sketchup_entity = sketchup_entity
-        @application_id = @sketchup_entity.persistent_id
+        @application_id = application_id
         @id = speckle_id
         @total_children_count = children.length
         @speckle_type = speckle_type

--- a/speckle_connector/src/speckle_entities/speckle_entity.rb
+++ b/speckle_connector/src/speckle_entities/speckle_entity.rb
@@ -41,7 +41,8 @@ module SpeckleConnector
 
       # @param sketchup_entity [Sketchup::Entity] sketchup entity represents {SpeckleEntity} on the model.
       # rubocop:disable Metrics/ParameterLists
-      def initialize(sketchup_entity, speckle_id, application_id, speckle_type, children, valid_stream_ids, invalid_stream_ids = [])
+      def initialize(sketchup_entity, speckle_id, application_id, speckle_type, children, valid_stream_ids,
+                     invalid_stream_ids = [])
         @status = SpeckleEntityStatus::UP_TO_DATE
         @source_material = sketchup_entity.material
         @active_diffing_stream_id = nil

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -200,12 +200,12 @@ module SpeckleConnector
         end
 
         DEFINITIONS_WILL_BE_SOFT_EDGE = %w[
-          Furniture-
-          Topography-
-          Column-
-          Lighting Fixtures-
-          Railings-
-          Roofs-
+          Furniture
+          Topography
+          Column
+          Lighting Fixtures
+          Railings
+          Roofs
         ].freeze
 
         # @param mesh [Object] speckle mesh object

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -115,17 +115,25 @@ module SpeckleConnector
           Objects.BuiltElements.Column
           Objects.BuiltElements.Beam
           Objects.BuiltElements.Roof
+          Objects.BuiltElements.Room
+          Objects.BuiltElements.Topography
         ].freeze
 
         def self.get_definition_name(def_obj)
-          return def_obj['name'] unless def_obj['name'].nil?
+          return def_obj['name'] if !def_obj['name'].nil? && !def_obj['is_sketchup_group'].nil?
+
+          family = def_obj['family']
+          type = def_obj['type']
+          category = def_obj['category']
 
           # Check unique elements when instancing implemented to add it with element id.
           if built_element?(def_obj) && unique_element?(def_obj)
-            return "#{def_obj['family']}-#{def_obj['type']}-#{def_obj['elementId']}"
+            element_id = def_obj['elementId']
+
+            return "#{family}-#{type}-#{category}-#{element_id}"
           end
 
-          return "#{def_obj['family']}-#{def_obj['type']}" if built_element?(def_obj)
+          return "#{family}-#{type}-#{category}" if built_element?(def_obj)
 
           return "def::#{def_obj['applicationId']}"
         end

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -122,10 +122,10 @@ module SpeckleConnector
 
           # Check unique elements when instancing implemented to add it with element id.
           if built_element?(def_obj) && unique_element?(def_obj)
-            return "#{def_obj['category']}-#{def_obj['family']}-#{def_obj['type']}-#{def_obj['elementId']}"
+            return "#{def_obj['family']}-#{def_obj['type']}-#{def_obj['elementId']}"
           end
 
-          return "#{def_obj['category']}-#{def_obj['family']}-#{def_obj['type']}" if built_element?(def_obj)
+          return "#{def_obj['family']}-#{def_obj['type']}" if built_element?(def_obj)
 
           return "def::#{def_obj['applicationId']}"
         end

--- a/speckle_connector/src/speckle_objects/other/block_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/block_instance.rb
@@ -182,18 +182,6 @@ module SpeckleConnector
           end
         end
 
-        def self.instance_to_speckle_entity(state, instance, speckle_instance, stream_id)
-          return state unless state.user_state.user_preferences[:register_speckle_entity]
-
-          speckle_id = speckle_instance['id']
-          speckle_type = speckle_instance['speckle_type']
-          children = speckle_instance['__closure'].nil? ? [] : speckle_instance['__closure']
-          ent = SpeckleEntities::SpeckleEntity.new(instance, speckle_id, speckle_type, children, [stream_id])
-          ent.write_initial_base_data
-          new_speckle_state = state.speckle_state.with_speckle_entity(ent)
-          state.with_speckle_state(new_speckle_state)
-        end
-
         # takes a component definition and finds and erases the first instance with the matching name
         # (and optionally the applicationId)
         # rubocop:disable Metrics/PerceivedComplexity


### PR DESCRIPTION
- [x] Definitions' naming structure is `{family}-{type}-{element_id}`.
- [x] By this way update procedure is implemented but continuos traversal should be enabled on settings. Otherwise there is no option to track objects.
- [x] Received objects collected under the same component with `{stream_name}-{branch_name}`

Closes #193