### PR TITLE
Fix (Instancing): Split revit instance from block instance

### DIFF
--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -3,6 +3,8 @@
 module SpeckleConnector
   BASE_OBJECT = 'Base'
 
+  OBJECTS_BUILTELEMENTS_VIEW3D = 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
+
   OBJECTS_GEOMETRY_LINE = 'Objects.Geometry.Line'
   OBJECTS_GEOMETRY_POLYLINE = 'Objects.Geometry.Polyline'
   OBJECTS_GEOMETRY_MESH = 'Objects.Geometry.Mesh'

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -413,6 +413,7 @@ module SpeckleConnector
         children = speckle_object['__closure'].nil? ? [] : speckle_object['__closure']
         speckle_state = state.speckle_state
         entities.each do |entity|
+          next if entity.is_a?(Sketchup::Material)
           next if (entity.is_a?(Sketchup::Face) || entity.is_a?(Sketchup::Edge)) &&
                   !state.user_state.user_preferences[:register_speckle_entity]
 

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'converter'
+require_relative '../constants/type_constants'
 require_relative '../speckle_objects/other/transform'
 require_relative '../speckle_objects/other/render_material'
 require_relative '../speckle_objects/other/block_definition'
@@ -10,6 +11,7 @@ require_relative '../speckle_objects/other/revit/revit_instance'
 require_relative '../speckle_objects/geometry/point'
 require_relative '../speckle_objects/geometry/line'
 require_relative '../speckle_objects/geometry/mesh'
+require_relative '../speckle_objects/built_elements/view3d'
 
 module SpeckleConnector
   module Converters
@@ -72,8 +74,8 @@ module SpeckleConnector
         # @Named Views are exception here. It does not mean a layer. But it is anti-pattern for now.
         filtered_layer_containers = obj.keys.filter_map { |key| key if key.start_with?('@') && key != '@Named Views' }
         create_layers(filtered_layer_containers, sketchup_model.layers)
-        views = collect_views(obj)
-        create_views(views, sketchup_model)
+        # Convert views to sketchup scenes
+        SpeckleObjects::BuiltElements::View3d.to_native(obj, sketchup_model)
         # Get default commit layer from sketchup model which will be used as fallback
         default_commit_layer = sketchup_model.layers.layers.find { |layer| layer.display_name == '@Untagged' }
         @entities_to_fill = entities_to_fill(obj)
@@ -181,45 +183,6 @@ module SpeckleConnector
         # Create layers that have parent folder(s)- this method is recursive until all tree is created.
         create_folder_layers(folder_layer_arrays, folder)
       end
-
-      def collect_views(obj)
-        views = []
-        views += obj.filter_map { |key, value| value if key == '@Named Views' }
-        views += obj.filter_map { |key, value| value if key == '@Views' } if from_revit
-        views.flatten
-      end
-
-      # @param views [Array] views.
-      # @param sketchup_model [Sketchup::Model] active sketchup model.
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Metrics/CyclomaticComplexity
-      def create_views(views, sketchup_model)
-        return if views.empty?
-
-        views.each do |view|
-          next unless view['speckle_type'] == 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
-
-          name = view['name'] || view['id']
-          next if sketchup_model.pages.any? { |page| page.name == name }
-
-          origin = view['origin']
-          target = view['target']
-          lens = view['lens'] || 50
-          origin = SpeckleObjects::Geometry::Point.to_native(origin['x'], origin['y'], origin['z'], origin['units'])
-          target = SpeckleObjects::Geometry::Point.to_native(target['x'], target['y'], target['z'], target['units'])
-          # Set camera position before creating scene on it.
-          my_camera = Sketchup::Camera.new(origin, target, [0, 0, 1], !view['isOrthogonal'], lens)
-          sketchup_model.active_view.camera = my_camera
-          sketchup_model.pages.add(name)
-          page = sketchup_model.pages[name]
-          set_page_update_properties(page, view['update_properties']) if view['update_properties']
-          set_rendering_options(page.rendering_options, view['rendering_options']) if view['rendering_options']
-        end
-      end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       # @param page [Sketchup::Page] scene to update -update properties-
       def set_page_update_properties(page, update_properties)

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -6,6 +6,7 @@ require_relative '../speckle_objects/other/render_material'
 require_relative '../speckle_objects/other/block_definition'
 require_relative '../speckle_objects/other/block_instance'
 require_relative '../speckle_objects/other/display_value'
+require_relative '../speckle_objects/other/revit/revit_instance'
 require_relative '../speckle_objects/geometry/point'
 require_relative '../speckle_objects/geometry/line'
 require_relative '../speckle_objects/geometry/mesh'
@@ -38,6 +39,7 @@ module SpeckleConnector
       MESH = GEOMETRY::Mesh
       BLOCK_DEFINITION = OTHER::BlockDefinition
       BLOCK_INSTANCE = OTHER::BlockInstance
+      REVIT_INSTANCE = OTHER::Revit::RevitInstance
       RENDER_MATERIAL = OTHER::RenderMaterial
       DISPLAY_VALUE = OTHER::DisplayValue
 
@@ -340,7 +342,7 @@ module SpeckleConnector
         OBJECTS_GEOMETRY_BREP => MESH.method(:to_native),
         OBJECTS_OTHER_BLOCKDEFINITION => BLOCK_DEFINITION.method(:to_native),
         OBJECTS_OTHER_BLOCKINSTANCE => BLOCK_INSTANCE.method(:to_native),
-        OBJECTS_OTHER_REVIT_REVITINSTANCE => BLOCK_INSTANCE.method(:to_native),
+        OBJECTS_OTHER_REVIT_REVITINSTANCE => REVIT_INSTANCE.method(:to_native),
         OBJECTS_OTHER_RENDERMATERIAL => RENDER_MATERIAL.method(:to_native)
       }.freeze
 

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -88,6 +88,8 @@ module SpeckleConnector
       end
 
       # Create levels from section planes that already created for this commit object.
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def create_levels_from_section_planes
         return unless from_revit
 
@@ -114,6 +116,8 @@ module SpeckleConnector
           [cline_1, cline_2, cline_3, cline_4, text, definition].each { |o| o.layer = levels_layer }
         end
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
       def entities_to_fill(_obj)
         return sketchup_model.entities if from_sketchup
@@ -188,6 +192,8 @@ module SpeckleConnector
       # @param views [Array] views.
       # @param sketchup_model [Sketchup::Model] active sketchup model.
       # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
       def create_views(views, sketchup_model)
         return if views.empty?
 
@@ -212,6 +218,8 @@ module SpeckleConnector
         end
       end
       # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       # @param page [Sketchup::Page] scene to update -update properties-
       def set_page_update_properties(page, update_properties)

--- a/speckle_connector/src/speckle_objects/built_elements/view3d.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/view3d.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative '../../constants/type_constants'
 require_relative '../../speckle_objects/geometry/point'
 require_relative '../../speckle_objects/geometry/vector'
 
@@ -9,7 +10,7 @@ module SpeckleConnector
     module BuiltElements
       # View3d object represents scenes on Sketchup.
       class View3d < Base
-        SPECKLE_TYPE = 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
+        SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_VIEW3D
 
         # @param name [String] name of the scene
         # @param origin [SpeckleObjects::Geometry::Point] origin (eye) of the view.
@@ -43,6 +44,50 @@ module SpeckleConnector
           self[:rendering_options] = rendering_options
         end
         # rubocop:enable Metrics/ParameterLists
+
+        # @param obj [Hash] commit object.
+        # @param sketchup_model [Sketchup::Model] active sketchup model.
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def self.to_native(obj, sketchup_model)
+          views = collect_views(obj)
+          return if views.empty?
+
+          views.each do |view|
+            next unless view['speckle_type'] == 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
+
+            name = view['name'] || view['id']
+            next if sketchup_model.pages.any? { |page| page.name == name }
+
+            origin = view['origin']
+            target = view['target']
+            lens = view['lens'] || 50
+            origin = SpeckleObjects::Geometry::Point.to_native(origin['x'], origin['y'], origin['z'], origin['units'])
+            target = SpeckleObjects::Geometry::Point.to_native(target['x'], target['y'], target['z'], target['units'])
+            # Set camera position before creating scene on it.
+            my_camera = Sketchup::Camera.new(origin, target, [0, 0, 1], !view['isOrthogonal'], lens)
+            sketchup_model.active_view.camera = my_camera
+            sketchup_model.pages.add(name)
+            page = sketchup_model.pages[name]
+            set_page_update_properties(page, view['update_properties']) if view['update_properties']
+            set_rendering_options(page.rendering_options, view['rendering_options']) if view['rendering_options']
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity
+
+        def self.collect_views(obj)
+          views = []
+          views += obj.filter_map do |_key, value|
+            if value.is_a?(Array) &&
+               value.any? { |v| v['speckle_type'] == OBJECTS_BUILTELEMENTS_VIEW3D }
+              value
+            end
+          end
+          views.flatten.select { |view| view['speckle_type'] == OBJECTS_BUILTELEMENTS_VIEW3D }
+        end
       end
     end
   end

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -199,13 +199,13 @@ module SpeckleConnector
           end
         end
 
-        DEFINITIONS_WILL_BE_SOFT_EDGE = %w[
-          Furniture
-          Topography
-          Column
-          Lighting Fixtures
-          Railings
-          Roofs
+        DEFINITIONS_WILL_BE_HARD_EDGE = %w[
+          Walls
+          Floors
+          Stairs
+          Structural Foundations
+          Doors
+          Windows
         ].freeze
 
         # @param mesh [Object] speckle mesh object
@@ -215,7 +215,7 @@ module SpeckleConnector
             return mesh['sketchup_attributes']['is_soften'].nil? ? true : mesh['sketchup_attributes']['is_soften']
           end
 
-          return DEFINITIONS_WILL_BE_SOFT_EDGE.any? { |def_name| entities.parent.name.include?(def_name) }
+          return DEFINITIONS_WILL_BE_HARD_EDGE.none? { |def_name| entities.parent.name.include?(def_name) }
         end
 
         def self.get_native_points(mesh)

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -100,40 +100,8 @@ module SpeckleConnector
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/ParameterLists
 
-        def self.built_element?(definition_object)
-          definition_object['speckle_type'].include?('Objects.BuiltElements')
-        end
-
-        def self.unique_element?(definition_object)
-          UNIQUE_DEFINITIONS.any? { |d| definition_object['speckle_type'].include?(d) }
-        end
-
-        UNIQUE_DEFINITIONS = %w[
-          Objects.BuiltElements.Wall
-          Objects.BuiltElements.Floor
-          Objects.BuiltElements.Ceiling
-          Objects.BuiltElements.Column
-          Objects.BuiltElements.Beam
-          Objects.BuiltElements.Roof
-          Objects.BuiltElements.Room
-          Objects.BuiltElements.Topography
-        ].freeze
-
         def self.get_definition_name(def_obj)
-          return def_obj['name'] if !def_obj['name'].nil? && !def_obj['is_sketchup_group'].nil?
-
-          family = def_obj['family']
-          type = def_obj['type']
-          category = def_obj['category']
-
-          # Check unique elements when instancing implemented to add it with element id.
-          if built_element?(def_obj) && unique_element?(def_obj)
-            element_id = def_obj['elementId']
-
-            return "#{family}-#{type}-#{category}-#{element_id}"
-          end
-
-          return "#{family}-#{type}-#{category}" if built_element?(def_obj)
+          return def_obj['name'] unless def_obj['name'].nil?
 
           return "def::#{def_obj['applicationId']}"
         end

--- a/speckle_connector/src/speckle_objects/other/display_value.rb
+++ b/speckle_connector/src/speckle_objects/other/display_value.rb
@@ -14,11 +14,37 @@ module SpeckleConnector
     module Other
       # DisplayValue object definition for Speckle that represents as BlockInstance in Sketchup.
       class DisplayValue
+        def self.get_definition_name(def_obj)
+          family = def_obj['family']
+          type = def_obj['type']
+          category = def_obj['category']
+          element_id = def_obj['elementId']
+
+          return format_naming_convention([family, type, category, element_id]) unless element_id.nil?
+
+          return "def::#{def_obj['applicationId']}"
+        end
+
+        def self.format_naming_convention(entries)
+          name = ''
+          entries.each_with_index do |entry, index|
+            next if entry.nil?
+
+            name += if index == entries.length - 1
+                      entry.to_s
+                    else
+                      "#{entry}-"
+                    end
+          end
+          name
+        end
+
         # Creates a component definition and instance from a speckle object with a display value
         # @param state [States::State] state of the application.
         def self.to_native(state, obj, layer, entities, &convert_to_native)
           # Switch displayValue with geometry
           obj = collect_definition_geometries(obj)
+          obj['name'] = get_definition_name(obj)
 
           state, _definitions = BlockDefinition.to_native(
             state,

--- a/speckle_connector/src/speckle_objects/other/revit/revit_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/revit/revit_definition.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../block_definition'
+require_relative '../../base'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module Other
+      module Revit
+        # RevitDefinition for Speckle.
+        class RevitDefinition < Base
+          SPECKLE_TYPE = OBJECTS_OTHER_REVIT_REVITINSTANCE
+
+          def self.get_definition_name(def_obj)
+            family = def_obj['family']
+            type = def_obj['type']
+            category = def_obj['category']
+
+            return "#{family}-#{type}-#{category}"
+          end
+
+          def self.to_native(state, definition, layer, entities, &convert_to_native)
+            definition_name = get_definition_name(definition)
+            definition['name'] = definition_name
+            BlockDefinition.to_native(state, definition, layer, entities, &convert_to_native)
+          end
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/other/revit/revit_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/revit/revit_instance.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative 'revit_definition'
+require_relative '../render_material'
+require_relative '../transform'
+require_relative '../block_definition'
+require_relative '../../base'
+require_relative '../../geometry/bounding_box'
+require_relative '../../../sketchup_model/dictionary/dictionary_handler'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module Other
+      module Revit
+        # RevitInstance object definition for Speckle.
+        class RevitInstance < Base
+          SPECKLE_TYPE = OBJECTS_OTHER_REVIT_REVITINSTANCE
+
+          # Creates a component instance from a block
+          # @param state [States::State] state of the application.
+          # @param block [Object] block object that represents Speckle block.
+          # @param layer [Sketchup::Layer] layer to add {Sketchup::Edge} into it.
+          # @param entities [Sketchup::Entities] entities collection to add {Sketchup::Edge} into it.
+          def self.to_native(state, block, layer, entities, &convert_to_native)
+
+            block_definition = block['definition']
+
+            state, _definitions = RevitDefinition.to_native(
+              state,
+              block_definition,
+              layer,
+              entities,
+              &convert_to_native
+            )
+
+            definition = state.sketchup_state.sketchup_model
+                              .definitions[RevitDefinition.get_definition_name(block_definition)]
+
+            return BlockInstance.add_instance_from_definition(state, block, layer, entities,
+                                                              definition, false, &convert_to_native)
+          end
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/other/revit/revit_instance.rb
+++ b/speckle_connector/src/speckle_objects/other/revit/revit_instance.rb
@@ -22,7 +22,6 @@ module SpeckleConnector
           # @param layer [Sketchup::Layer] layer to add {Sketchup::Edge} into it.
           # @param entities [Sketchup::Entities] entities collection to add {Sketchup::Edge} into it.
           def self.to_native(state, block, layer, entities, &convert_to_native)
-
             block_definition = block['definition']
 
             state, _definitions = RevitDefinition.to_native(


### PR DESCRIPTION
Way we handle revit instances was a generic way but it required some hard coded list to separate apples and oranges. Because of this reason I've created new object definition for RevitInstance.