### PR TITLE
Fix (Instancing): Support nested families

### DIFF
--- a/speckle_connector/src/speckle_objects/other/revit/revit_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/revit/revit_definition.rb
@@ -22,6 +22,7 @@ module SpeckleConnector
           def self.to_native(state, definition, layer, entities, &convert_to_native)
             definition_name = get_definition_name(definition)
             definition['name'] = definition_name
+            definition['displayValue'] += definition['elements'] unless definition['elements'].nil?
             BlockDefinition.to_native(state, definition, layer, entities, &convert_to_native)
           end
         end


### PR DESCRIPTION
Nested families fall off the radar before. Now we add elements of the RevitDefinition if exist to displayValue to handle nestedly. 