### PR TITLE
Fix (Instancing): Support nested families re-fix

### DIFF
--- a/speckle_connector/src/speckle_objects/other/revit/revit_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/revit/revit_definition.rb
@@ -22,6 +22,7 @@ module SpeckleConnector
           def self.to_native(state, definition, layer, entities, &convert_to_native)
             definition_name = get_definition_name(definition)
             definition['name'] = definition_name
+            definition['displayValue'] += definition['elements'] unless definition['elements'].nil?
             BlockDefinition.to_native(state, definition, layer, entities, &convert_to_native)
           end
         end

--- a/speckle_connector/src/speckle_objects/other/transform.rb
+++ b/speckle_connector/src/speckle_objects/other/transform.rb
@@ -11,8 +11,7 @@ module SpeckleConnector
 
         # @param units [String] units of the transform.
         # @param value [Array<Numeric>] values of the transform.
-        # @param sketchup_attributes [Other::BlockDefinition] sketchup attributes of the transform.
-        def initialize(units:, value:, sketchup_attributes: {})
+        def initialize(units:, value:)
           super(
             speckle_type: SPECKLE_TYPE,
             total_children_count: 0,
@@ -21,7 +20,6 @@ module SpeckleConnector
           )
           self[:units] = units
           self[:value] = value
-          self[:sketchup_attributes] = sketchup_attributes
         end
 
         def self.from_transformation(transformation, units)


### PR DESCRIPTION
Nested families fall off the radar before. Now we add elements of the RevitDefinition if exist to displayValue to handle nestedly.
There was a confusion before, some commit mislead me, now it is refixed.