### PR TITLE
Feat (Observers): Selection observers to collect data

### DIFF
--- a/speckle_connector/src/actions/events/selection_event_action.rb
+++ b/speckle_connector/src/actions/events/selection_event_action.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'event_action'
+
+module SpeckleConnector
+  module Actions
+    module Events
+      # Update selected speckle objects when the selection changes for mapping tool.
+      class SelectionEventAction < EventAction
+        # @param state [States::State] the current state of Speckle application.
+        # @return [States::State] the new updated state object
+        def self.update_state(state, event_data)
+          return state unless event_data&.any?
+
+          state.with_selection_queue(selection)
+          # Handle here message to UI according to selection!
+          state
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/events/selection_event_action.rb
+++ b/speckle_connector/src/actions/events/selection_event_action.rb
@@ -12,9 +12,13 @@ module SpeckleConnector
         def self.update_state(state, event_data)
           return state unless event_data&.any?
 
+          selection = [
+            {a: 1},
+            {b: 1}
+          ]
+          selection = [] if state.sketchup_state.sketchup_model.selection.none?
+
           state.with_selection_queue(selection)
-          # Handle here message to UI according to selection!
-          state
         end
       end
     end

--- a/speckle_connector/src/actions/events/selection_event_action.rb
+++ b/speckle_connector/src/actions/events/selection_event_action.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'event_action'
+require_relative '../../mapping/category/revit_category'
 
 module SpeckleConnector
   module Actions
@@ -12,11 +13,17 @@ module SpeckleConnector
         def self.update_state(state, event_data)
           return state unless event_data&.any?
 
-          selection = [
-            {a: 1},
-            {b: 1}
-          ]
-          selection = [] if state.sketchup_state.sketchup_model.selection.none?
+          selection = {
+            selection: [
+              { a: 1 },
+              { b: 1 }
+            ],
+            mappingMethods: [
+              'Direct Shape'
+            ],
+            categories: Mapping::Category::RevitCategory.dictionary.keys.to_a
+          }
+          selection = { selection: [], mappingMethods: [], categories: [] } if state.sketchup_state.sketchup_model.selection.none?
 
           state.with_selection_queue(selection)
         end

--- a/speckle_connector/src/actions/initialize_speckle.rb
+++ b/speckle_connector/src/actions/initialize_speckle.rb
@@ -23,6 +23,7 @@ module SpeckleConnector
         preferences = Preferences.read_preferences(sketchup_state.sketchup_model)
         user_state_with_preferences = state.user_state.with_preferences(preferences)
         state = States::State.new(user_state_with_preferences, speckle_state, sketchup_state, false)
+        # This is where we attach observers to related model objects like selection, entities..
         Actions::LoadSketchupModel.update_state(state, sketchup_state.sketchup_model)
       end
 

--- a/speckle_connector/src/actions/load_sketchup_model.rb
+++ b/speckle_connector/src/actions/load_sketchup_model.rb
@@ -42,8 +42,8 @@ module SpeckleConnector
       # @param sketchup_model [Sketchup::Model] the model to attach observers to
       # @param observers [Hash{Class=>}] the observer objects indexed by their class that will be attached
       def self.attach_observers(sketchup_model, observers)
-        # selection = sketchup_model.selection
-        # selection.add_observer(observers[SELECTION_OBSERVER_NAME])
+        selection = sketchup_model.selection
+        selection.add_observer(observers[SELECTION_OBSERVER])
         # layers = sketchup_model.layers
         # layers.add_observer(observers[LAYERS_OBSERVER_NAME])
         entities = sketchup_model.entities

--- a/speckle_connector/src/actions/on_events_action.rb
+++ b/speckle_connector/src/actions/on_events_action.rb
@@ -4,6 +4,7 @@ require_relative 'action'
 require_relative 'events/app_event_action'
 require_relative 'events/entities_event_action'
 require_relative 'events/model_event_action'
+require_relative 'events/selection_event_action'
 require_relative '../constants/observer_constants'
 
 module SpeckleConnector
@@ -13,11 +14,11 @@ module SpeckleConnector
       RUN_ORDER = {
         APP_OBSERVER => Events::AppEventAction,
         ENTITIES_OBSERVER => Events::EntitiesEventAction,
-        MODEL_OBSERVER => Events::ModelEventAction
+        MODEL_OBSERVER => Events::ModelEventAction,
         # MATERIALS_OBSERVER => Events::MaterialsEventAction,
         # LAYERS_OBSERVER => Events::LayerEventAction,
         # PAGES_OBSERVER => Events::PagesEventAction,
-        # SELECTION_OBSERVER => Events::SelectionEventAction
+        SELECTION_OBSERVER => Events::SelectionEventAction
       }.freeze
 
       def self.update_state(state, events)

--- a/speckle_connector/src/constants/observer_constants.rb
+++ b/speckle_connector/src/constants/observer_constants.rb
@@ -4,4 +4,5 @@ module SpeckleConnector
   APP_OBSERVER = 'SpeckleConnector::Observers::AppObserver'
   ENTITIES_OBSERVER = 'SpeckleConnector::Observers::EntitiesObserver'
   MODEL_OBSERVER = 'SpeckleConnector::Observers::ModelObserver'
+  SELECTION_OBSERVER = 'SpeckleConnector::Observers::SelectionObserver'
 end

--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -12,7 +12,7 @@ require_relative '../speckle_objects/other/rendering_options'
 require_relative '../speckle_objects/built_elements/view3d'
 require_relative '../speckle_objects/built_elements/revit/direct_shape'
 require_relative '../constants/path_constants'
-require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+require_relative '../sketchup_model/reader/speckle_entities_reader'
 require_relative '../sketchup_model/query/entity'
 
 module SpeckleConnector
@@ -46,7 +46,9 @@ module SpeckleConnector
                                      sketchup_model.selection,
                                      [Sketchup::Face, Sketchup::ComponentInstance, Sketchup::Group], [sketchup_model]
                                    )
-        flat_selection_with_path.select { |entities| mapped_with_schema?(entities[0]) }
+        flat_selection_with_path.select do |entities|
+          SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entities[0])
+        end
       end
 
       # Add views from pages.
@@ -112,17 +114,11 @@ module SpeckleConnector
       def convert(entity, preferences, speckle_state, parent = :base)
         convert = method(:convert)
 
-        unless mapped_with_schema?(entity)
+        unless SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entity)
           return from_native_to_speckle(entity, preferences, speckle_state, parent, &convert)
         end
 
         return speckle_state, nil
-      end
-
-      # Checks entity is mapped or not.
-      # @param entity [Sketchup::Entity] entity to check whether is mapped or not.
-      def mapped_with_schema?(entity)
-        !SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity).nil?
       end
 
       def from_mapped_to_speckle(entity, path, preferences)

--- a/speckle_connector/src/observers/factory.rb
+++ b/speckle_connector/src/observers/factory.rb
@@ -5,6 +5,7 @@ require_relative 'entities_observer'
 require_relative 'observer_handler'
 require_relative 'model_observer'
 require_relative 'event_handler'
+require_relative 'selection_observer'
 require_relative '../constants/observer_constants'
 
 module SpeckleConnector
@@ -22,7 +23,8 @@ module SpeckleConnector
         {
           APP_OBSERVER => AppObserver.new(handler),
           ENTITIES_OBSERVER => EntitiesObserver.new(handler),
-          MODEL_OBSERVER => ModelObserver.new(handler)
+          MODEL_OBSERVER => ModelObserver.new(handler),
+          SELECTION_OBSERVER => SelectionObserver.new(handler)
         }.freeze
       end
     end

--- a/speckle_connector/src/observers/selection_observer.rb
+++ b/speckle_connector/src/observers/selection_observer.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'event_observer'
+
+module SpeckleConnector
+  module Observers
+    # @see https://ruby.sketchup.com/Sketchup/SelectionObserver.html
+    class SelectionObserver < Sketchup::SelectionObserver
+      include EventObserver
+
+      # rubocop:disable Naming/MethodName
+      # @param _selection (Sketchup::Selection)
+      # @param _entity (Sketchup::Entity)
+      def onSelectionAdded(_selection, _entity)
+        push_selection_event(:onSelectionAdded)
+      end
+
+      # @param _selection (Sketchup::Selection)
+      def onSelectionBulkChange(_selection)
+        push_selection_event(:onSelectionBulkChange)
+      end
+
+      # @param _selection (Sketchup::Selection)
+      def onSelectionCleared(_selection)
+        push_selection_event(:onSelectionCleared)
+      end
+
+      # @param _selection (Sketchup::Selection)
+      def onSelectionRemoved(_selection, _entity)
+        push_selection_event(:onSelectionRemoved)
+      end
+
+      # Due to a SketchUp bug, this method is called by the wrong name.
+      alias onSelectedRemoved onSelectionRemoved
+      # rubocop:enable Naming/MethodName
+
+      private
+
+      # Selection changes need to be registered only once
+      def push_selection_event(event_name)
+        # Don't push anything if the selection event was already registered
+        selection_events = observer_handler.events[self.class]
+        return if selection_events&.any?
+
+        push_event(event_name)
+      end
+    end
+  end
+end

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../dictionary/speckle_schema_dictionary_handler'
 require_relative '../../speckle_entities/speckle_entity'
 require_relative '../../constants/dict_constants'
 
@@ -45,6 +46,11 @@ module SpeckleConnector
           return false if entity.attribute_dictionaries.to_a.empty?
 
           entity.attribute_dictionaries.to_a.any? { |dict| dict.name == SPECKLE_BASE_OBJECT }
+        end
+
+        # @param entity [Sketchup::Entity] sketchup entity to check whether mapped with speckle schema or not.
+        def self.mapped_with_schema?(entity)
+          !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity).nil?
         end
       end
     end

--- a/speckle_connector/src/states/speckle_state.rb
+++ b/speckle_connector/src/states/speckle_state.rb
@@ -58,6 +58,17 @@ module SpeckleConnector
         with(:@message_queue => new_queue)
       end
 
+      def with_selection_queue(selection_parameters)
+        new_queue = message_queue.merge({ "entitySelected":
+                                            "entitySelected(#{JSON.generate(selection_parameters)})" })
+        with(:@message_queue => new_queue)
+      end
+
+      def with_deselection_queue
+        new_queue = message_queue.merge({ "entitiesDeselected": 'entitiesDeselected()' })
+        with(:@message_queue => new_queue)
+      end
+
       def with_invalid_streams_queue
         new_queue = message_queue.merge({ "updateInvalidStreams":
                                             "updateInvalidStreams(#{JSON.generate(invalid_streams)})" })

--- a/speckle_connector/src/states/state.rb
+++ b/speckle_connector/src/states/state.rb
@@ -36,6 +36,15 @@ module SpeckleConnector
         with(:@speckle_state => new_speckle_state)
       end
 
+      def with_selection_queue(selection_parameters)
+        new_speckle_state = if selection_parameters.any?
+                              speckle_state.with_selection_queue(selection_parameters)
+                            else
+                              speckle_state.with_deselection_queue
+                            end
+        with(:@speckle_state => new_speckle_state)
+      end
+
       def with_empty_stream_queue
         new_speckle_state = speckle_state.with(:@stream_queue => {})
         with(:@speckle_state => new_speckle_state)

--- a/speckle_connector/src/states/state.rb
+++ b/speckle_connector/src/states/state.rb
@@ -37,7 +37,7 @@ module SpeckleConnector
       end
 
       def with_selection_queue(selection_parameters)
-        new_speckle_state = if selection_parameters.any?
+        new_speckle_state = if selection_parameters[:selection].any?
                               speckle_state.with_selection_queue(selection_parameters)
                             else
                               speckle_state.with_deselection_queue

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -2,20 +2,27 @@
   <v-container fluid class="px-5 btn-container">
     <v-autocomplete
         label="Mapper Method"
+        :disabled="!entitySelected"
         :items="['Direct Shape']"
         density="compact"
     ></v-autocomplete>
 
     <v-autocomplete
         :items="availableCategories"
+        :disabled="!entitySelected"
         label="Category"
         density="compact"
     ></v-autocomplete>
 
-    <v-text-field v-model="name" label="Name"></v-text-field>
+    <v-text-field
+        v-model="name"
+        label="Name"
+        :disabled="!entitySelected"
+    ></v-text-field>
 
     <v-btn
         class="ma-2 pa-3"
+        :disabled="!entitySelected"
     >
       <v-icon dark left>
         mdi-checkbox-marked-circle
@@ -28,8 +35,8 @@
 
 import {bus} from "@/main";
 
-global.entitySelected = function (mapperProperties) {
-  bus.$emit('entities-selected', mapperProperties)
+global.entitySelected = function (selectionParameters) {
+  bus.$emit('entities-selected', selectionParameters)
 }
 
 global.entitiesDeselected = function () {
@@ -58,11 +65,11 @@ export default {
     }
   },
   mounted() {
-    bus.$on('entities-selected', async (mapperProperties) => {
+    bus.$on('entities-selected', async (selectionParameters) => {
       this.entitySelected = true
-      const mapperProps = JSON.parse(mapperProperties)
-      this.enabledMethods = mapperProps.enabledMethods
-      this.selectedObjects = mapperProps.selectedObjects
+      const selectionParams = JSON.parse(selectionParameters)
+      this.enabledMethods = selectionParams.enabledMethods
+      this.selectedObjects = selectionParams.selectedObjects
       this.selectedObjectCount = this.selectedObjects.length
     })
     bus.$on('entities-deselected', async () => {

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -1,33 +1,87 @@
 <template>
   <v-container fluid class="px-5 btn-container">
-    <v-autocomplete
-        label="Mapper Method"
-        :disabled="!entitySelected"
-        :items="['Direct Shape']"
-        density="compact"
-    ></v-autocomplete>
 
-    <v-autocomplete
-        :items="availableCategories"
-        :disabled="!entitySelected"
-        label="Category"
-        density="compact"
-    ></v-autocomplete>
-
-    <v-text-field
-        v-model="name"
-        label="Name"
-        :disabled="!entitySelected"
-    ></v-text-field>
-
-    <v-btn
-        class="ma-2 pa-3"
-        :disabled="!entitySelected"
+    <v-expansion-panels
+      v-model="panel"
+      accordion
+      multiple
+      expand
     >
-      <v-icon dark left>
-        mdi-checkbox-marked-circle
-      </v-icon>Apply Mappings
-    </v-btn>
+      <v-expansion-panel key="selection">
+        <v-expansion-panel-header>
+          <div>
+            <v-icon>
+              {{ selectedEntityCount === 0 ? 'mdi-playlist-remove' : 'mdi-playlist-check' }}
+            </v-icon>
+            {{ `Selection (${selectedEntityCount})` }}
+          </div>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          {{"test"}}
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+      <v-expansion-panel key="mapping">
+        <v-expansion-panel-header>
+          <div>
+            <v-icon>
+              mdi-multiplication
+            </v-icon>
+            {{ `Mapping` }}
+          </div>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <v-autocomplete
+              v-model="selectedMethod"
+              class="pt-0"
+              label="Mapper Method"
+              :disabled="!entitySelected"
+              :items="enabledMethods"
+              density="compact"
+          ></v-autocomplete>
+
+          <v-autocomplete
+              v-model="selectedCategory"
+              class="pt-0"
+              label="Category"
+              :items="availableCategories"
+              :disabled="!entitySelected"
+              density="compact"
+          ></v-autocomplete>
+
+          <v-text-field
+              v-model="name"
+              class="pt-0"
+              label="Name"
+              :disabled="!entitySelected"
+          ></v-text-field>
+
+          <v-btn
+              class="ma-2 pa-3"
+              :disabled="!entitySelected"
+          >
+            <v-icon dark left>
+              mdi-checkbox-marked-circle
+            </v-icon>Apply Mappings
+          </v-btn>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+      <v-expansion-panel key="mappedElements">
+        <v-expansion-panel-header>
+          <div>
+            <v-icon>
+              {{ mappedEntityCount === 0 ? 'mdi-playlist-remove' : 'mdi-playlist-check' }}
+            </v-icon>
+            {{ `Mapped Elements (${mappedEntityCount})` }}
+          </div>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          {{"test"}}
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+    </v-expansion-panels>
   </v-container>
 </template>
 
@@ -36,7 +90,7 @@
 import {bus} from "@/main";
 
 global.entitySelected = function (selectionParameters) {
-  bus.$emit('entities-selected', selectionParameters)
+  bus.$emit('entities-selected', JSON.stringify(selectionParameters))
 }
 
 global.entitiesDeselected = function () {
@@ -48,30 +102,38 @@ export default {
   data() {
     return {
       entitySelected: false,
+      selectedEntityCount: 0,
+      selectedEntities: [],
       selectedMethod: null,
       selectedCategory: null,
-      selectedObjects: [],
-      selectedObjectCount: null,
       name: "",
       enabledMethods: [],
-      availableCategories: ["Floors", "Walls", "Windows"],
+      availableCategories: [],
+      mappedEntityCount: 0,
+      mappedEntities: [],
+      panel: [1]
     }
   },
   methods:{
     clearInputs(){
       this.enabledMethods = []
-      this.selectedObjects = []
+      this.availableCategories = []
+      this.selectedEntities = []
+      this.selectedEntityCount = 0
       this.name = ""
+      this.selectedMethod = null
+      this.selectedCategory = null
     }
   },
   mounted() {
     bus.$on('entities-selected', async (selectionParameters) => {
       this.entitySelected = true
-      const selectionParams = JSON.parse(selectionParameters)
-      this.enabledMethods = selectionParams.enabledMethods
-      this.selectedObjects = selectionParams.selectedObjects
-      this.selectedObjectCount = this.selectedObjects.length
-      this.entitySelected = this.selectedObjectCount !== 0
+      const selectionPars = JSON.parse(selectionParameters)
+      this.enabledMethods = selectionPars.mappingMethods
+      this.availableCategories = selectionPars.categories
+      this.selectedEntities = selectionPars.selection
+      this.selectedEntityCount = this.selectedEntities.length
+      this.entitySelected = this.selectedEntityCount !== 0
     })
     bus.$on('entities-deselected', async () => {
       this.entitySelected = false

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -71,6 +71,7 @@ export default {
       this.enabledMethods = selectionParams.enabledMethods
       this.selectedObjects = selectionParams.selectedObjects
       this.selectedObjectCount = this.selectedObjects.length
+      this.entitySelected = this.selectedObjectCount !== 0
     })
     bus.$on('entities-deselected', async () => {
       this.entitySelected = false


### PR DESCRIPTION
Selection observers are atteched to the `selection` of active model on the state. So we can track now state of the selection with it's handler action. By this way we will be able to pass relevant data to UI map objects.