### PR TITLE
Fix (Mapper): Group global transformations for direct shapes

### DIFF
--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -144,7 +144,8 @@ module SpeckleConnector
         end
 
         if entity.is_a?(Sketchup::Face)
-          mesh = SpeckleObjects::Geometry::Mesh.from_face(entity, @units, preferences[:model])
+          mesh = SpeckleObjects::Geometry::Mesh.from_face(face: entity, units: @units,
+                                                          model_preferences: preferences[:model])
           return speckle_state, [mesh, [entity]]
         end
 

--- a/speckle_connector/src/mapping/category/revit_category.rb
+++ b/speckle_connector/src/mapping/category/revit_category.rb
@@ -3,6 +3,7 @@
 module SpeckleConnector
   module Mapping
     module Category
+      # Revit categories.
       class RevitCategory < Hash
         class << self
           # rubocop:disable Metrics/MethodLength

--- a/speckle_connector/src/sketchup_model/query/entity.rb
+++ b/speckle_connector/src/sketchup_model/query/entity.rb
@@ -91,6 +91,16 @@ module SpeckleConnector
             end
             instances.first
           end
+
+          # Finds first material of parents from bottom to top.
+          def parent_material(path)
+            material = nil
+            path.reverse.each do |local|
+              material = local.material if local.respond_to?(:material)
+              return material unless material.nil?
+            end
+            material
+          end
         end
       end
     end

--- a/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../base'
+require_relative '../../other/render_material'
 require_relative '../../../constants/type_constants'
 require_relative '../../../sketchup_model/query/entity'
 
@@ -30,21 +31,28 @@ module SpeckleConnector
             if schema.nil? && entity.respond_to?(:definition)
               schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity.definition)
             end
-            entities = []
-            entities.append(entity) if entity.is_a?(Sketchup::Face) || entity.is_a?(Sketchup::Edge)
+            entities_with_path = []
+            entities_with_path.append([entity] + path) if entity.is_a?(Sketchup::Face) || entity.is_a?(Sketchup::Edge)
             # Collect here flat list
             if entity.is_a?(Sketchup::ComponentInstance) || entity.is_a?(Sketchup::Group)
               # entities.append(entity)
-              entities += SketchupModel::Query::Entity.flat_entities(entity.definition.entities, [Sketchup::Face])
+              entities_with_path += SketchupModel::Query::Entity
+                                    .flat_entities_with_path(
+                                      entity.definition.entities,
+                                      [Sketchup::Face], path.append(entity)
+                                    )
             end
             base_geometries = []
-            entities.each do |e|
+            entities_with_path.each do |entity_with_path|
+              e = entity_with_path[0]
+              entity_path = entity_with_path[1..-1]
               # next if entity.is_a?(Sketchup::Edge) && entity.faces.any?
               next unless e.is_a?(Sketchup::Face)
 
               mesh = SpeckleObjects::Geometry::Mesh
-                     .from_face(e, units, preferences[:model],
-                                SketchupModel::Query::Entity.global_transformation(entity, path))
+                     .from_face(face: e, units: units, model_preferences: preferences[:model],
+                                global_transform: SketchupModel::Query::Entity.global_transformation(e, entity_path),
+                                parent_material: SketchupModel::Query::Entity.parent_material(entity_path))
               base_geometries.append(mesh)
             end
             DirectShape.new(

--- a/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
@@ -26,6 +26,10 @@ module SpeckleConnector
             self[:baseGeometries] = base_geometries
           end
 
+          # rubocop:disable Metrics/AbcSize
+          # rubocop:disable Metrics/CyclomaticComplexity
+          # rubocop:disable Metrics/MethodLength
+          # rubocop:disable Metrics/PerceivedComplexity
           def self.from_entity(entity, path, units, preferences)
             schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity)
             if schema.nil? && entity.respond_to?(:definition)
@@ -63,6 +67,10 @@ module SpeckleConnector
               application_id: entity.persistent_id
             )
           end
+          # rubocop:enable Metrics/AbcSize
+          # rubocop:enable Metrics/CyclomaticComplexity
+          # rubocop:enable Metrics/MethodLength
+          # rubocop:enable Metrics/PerceivedComplexity
         end
       end
     end

--- a/speckle_connector/src/speckle_objects/geometry/line.rb
+++ b/speckle_connector/src/speckle_objects/geometry/line.rb
@@ -87,7 +87,6 @@ module SpeckleConnector
 
         def self.test_line(start_point, end_point, units)
           domain = Primitive::Interval.from_numeric(0, 5, units)
-          bbox = Geometry::BoundingBox.test_bounds(units)
           Line.new(
             start_pt: start_point,
             end_pt: end_point,

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -108,17 +108,17 @@ module SpeckleConnector
         # @param global_transform [Geom::Transformation, nil] global transformation value of face if it is not included
         #  into any component.
         # rubocop:disable Style/MultilineTernaryOperator
-        def self.from_face(face, units, model_preferences, global_transform = nil)
+        def self.from_face(face:, units:, model_preferences:, global_transform: nil, parent_material: nil)
           dictionaries = SketchupModel::Dictionary::BaseDictionaryHandler
                          .attribute_dictionaries_to_speckle(face, model_preferences)
           has_any_soften_edge = face.edges.any?(&:soft?)
           att = dictionaries.any? ? { is_soften: has_any_soften_edge, dictionaries: dictionaries }
                   : { is_soften: has_any_soften_edge }
           speckle_schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(face)
+          material = face.material || face.back_material || parent_material
           speckle_mesh = Mesh.new(
             units: units,
-            render_material: face.material.nil? && face.back_material.nil? ? nil : Other::RenderMaterial
-                                                          .from_material(face.material || face.back_material),
+            render_material: material.nil? ? nil : Other::RenderMaterial.from_material(material),
             vertices: [],
             faces: [],
             sketchup_attributes: att,


### PR DESCRIPTION
There was a bug for global transformations for sub objects. It is corrected for each entity under the groups or components.