### PR TITLE
Fix (Mapper): Direct shape objects on viewer

### DIFF
--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -30,7 +30,7 @@ module SpeckleConnector
           layer_name = entity_layer_path(entity)
           layers[layer_name].push(converted_object_with_entity)
         end
-        layers['DirectShape'] = direct_shapes.collect do |entities|
+        layers['@DirectShape'] = direct_shapes.collect do |entities|
           from_mapped_to_speckle(entities[0], entities[1..-1], preferences)
         end
         # send only+ layers that have any object


### PR DESCRIPTION
Direct shape elements on the list couldn't detected as object by viewer because previously is not detached. When we detach collections it's objects now can be open new window separately.