### PR TITLE
Fix (DirectShape): Nested objects material

### DIFF
--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -28,7 +28,7 @@ module SpeckleConnector
           new_speckle_state, converted_object_with_entity = convert(entity, preferences, state)
           state = new_speckle_state
           layer_name = entity_layer_path(entity)
-          layers[layer_name].push(converted_object_with_entity)
+          layers[layer_name].push(converted_object_with_entity) unless converted_object_with_entity.nil?
         end
         layers['@DirectShape'] = direct_shapes.collect do |entities|
           from_mapped_to_speckle(entities[0], entities[1..-1], preferences)

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -62,7 +62,11 @@ module SpeckleConnector
 
         # @param entity [Sketchup::Entity] sketchup entity to check whether mapped with speckle schema or not.
         def self.mapped_with_schema?(entity)
-          !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity).nil?
+          is_entity_mapped = !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity).nil?
+          return is_entity_mapped if is_entity_mapped
+          return is_entity_mapped unless entity.is_a?(Sketchup::ComponentInstance)
+
+          !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity.definition).nil?
         end
 
         def self.get_schema(entity)

--- a/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
@@ -52,7 +52,8 @@ module SpeckleConnector
             faces_with_path.each do |face_with_path|
               face = face_with_path[0]
               entity_path = face_with_path[1..-1]
-              mesh_group_id = Geometry::Mesh.get_mesh_group_id(face, preferences[:model], entity_path)
+              parent_material = SketchupModel::Query::Entity.parent_material(entity_path)
+              mesh_group_id = Geometry::Mesh.get_mesh_group_id(face, preferences[:model], parent_material)
 
               if mesh_groups.key?(mesh_group_id)
                 mesh_group = mesh_groups[mesh_group_id]
@@ -62,7 +63,7 @@ module SpeckleConnector
                 mesh = Geometry::Mesh.from_face(
                   face: face, units: units, model_preferences: preferences[:model],
                   global_transform: SketchupModel::Query::Entity.global_transformation(face, entity_path),
-                  parent_material: SketchupModel::Query::Entity.parent_material(entity_path)
+                  parent_material: parent_material
                 )
                 mesh_groups[mesh_group_id] = [mesh, [face]]
               end

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -242,17 +242,14 @@ module SpeckleConnector
 
         # Mesh group id helps to determine how to group faces into meshes.
         # @param face [Sketchup::Face] face to get mesh group id.
-        def self.get_mesh_group_id(face, model_preferences, face_path = nil)
+        def self.get_mesh_group_id(face, model_preferences, parent_material = nil)
           if model_preferences[:include_entity_attributes] &&
              model_preferences[:include_face_entity_attributes] &&
              attribute_dictionary?(face)
             return face.persistent_id.to_s
           end
 
-          material = face.material || face.back_material
-          return 'none' if material.nil? && face_path.nil?
-
-          material = SketchupModel::Query::Entity.parent_material(face_path) unless face_path.nil?
+          material = face.material || face.back_material || parent_material
           return 'none' if material.nil?
 
           return material.entityID.to_s


### PR DESCRIPTION
There was a unneccessary assignment before while checking parent materials which is eliminated. Another bug fixed by excluding mapped entities to layer collections. Previously we were adding it as null.