### PR TITLE
Feat (Mapper): Mapped elements table and it's buttons

### DIFF
--- a/speckle_connector/src/actions/apply_mappings.rb
+++ b/speckle_connector/src/actions/apply_mappings.rb
@@ -39,8 +39,13 @@ module SpeckleConnector
         # Store speckle state to update with mapped entities.
         speckle_state = state.speckle_state
         entities_to_map.each do |entity|
+          name = if @name == '<Mixed>'
+                   entity.respond_to?(:name) ? entity.name : ''
+                 else
+                   @name
+                 end
           SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :category, @category)
-          SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :name, @name)
+          SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :name, name)
           SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :method, @method)
           speckle_state = speckle_state.with_mapped_entity(entity)
         end

--- a/speckle_connector/src/actions/clear_mappings_from_table.rb
+++ b/speckle_connector/src/actions/clear_mappings_from_table.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+require_relative 'mapped_entities_updated'
+require_relative 'events/selection_event_action'
+require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  module Actions
+    # Clear mappings for selected entities from mapped elements table.
+    class ClearMappingsFromTable < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, data)
+        # Flat entities to clear mappings
+        flat_entities = SketchupModel::Query::Entity.flat_entities(state.sketchup_state.sketchup_model.entities)
+
+        # Collect entity ids to clear mappings
+        entity_ids = data.collect { |_, entities| entities['selectedElements'].collect { |e| e['entityId'] } }.flatten
+        # Store speckle state to update with mapped entities.
+        speckle_state = state.speckle_state
+        flat_entities.each do |entity|
+          next unless entity_ids.include?(entity.persistent_id)
+
+          SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.remove_dictionary(entity)
+          speckle_state = speckle_state.with_removed_mapped_entity(entity)
+        end
+
+        new_state = MappedEntitiesUpdated.update_state(state.with_speckle_state(speckle_state))
+        Events::SelectionEventAction.update_state(new_state, { clear: true })
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/hide_mappings_from_table.rb
+++ b/speckle_connector/src/actions/hide_mappings_from_table.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+require_relative 'events/selection_event_action'
+require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  module Actions
+    # Hide entities that selected from mapped elements table.
+    class HideMappingsFromTable < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, data)
+        # Flat entities to clear mappings
+        flat_entities = SketchupModel::Query::Entity.flat_entities(state.sketchup_state.sketchup_model.entities)
+
+        # Collect entity ids to clear mappings
+        entity_ids = data.collect { |_, entities| entities['selectedElements'].collect { |e| e['entityId'] } }.flatten
+
+        # Store speckle state to update with mapped entities.
+        flat_entities.each do |entity|
+          next unless entity_ids.include?(entity.persistent_id)
+
+          entity.hidden = true
+        end
+
+        Events::SelectionEventAction.update_state(state, { clear: true })
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/isolate_mappings_from_table.rb
+++ b/speckle_connector/src/actions/isolate_mappings_from_table.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+require_relative 'events/selection_event_action'
+require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  module Actions
+    # Isolate entities that selected from mapped elements table.
+    class IsolateMappingsFromTable < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, data)
+        sketchup_model = state.sketchup_state.sketchup_model
+        # Flat entities to clear mappings
+        comp_flat_entities = SketchupModel::Query::Entity.flat_entities(
+          sketchup_model.entities, [Sketchup::ComponentInstance, Sketchup::Group]
+        )
+        flat_entities = SketchupModel::Query::Entity.flat_entities(sketchup_model.entities)
+
+        # Collect entity ids to clear mappings
+        selected_elements = data.collect { |_, entities| entities['selectedElements'] }.flatten
+
+        comps_or_groups, faces_or_edges = selected_elements.partition do |e|
+          e['entityType'] == 'Component' || e['entityType'] == 'Group'
+        end
+
+        entity_ids = faces_or_edges.collect { |e| e['entityId'] }
+
+        comps_or_groups.each do |e|
+          entity = comp_flat_entities.find { |flat_e| flat_e.persistent_id == e['entityId'] }
+          entities_for_definition = SketchupModel::Query::Entity.flat_entities(entity.definition.entities)
+          entity_ids += entities_for_definition.collect(&:persistent_id) + [entity.persistent_id]
+        end
+
+        # Store speckle state to update with mapped entities.
+        flat_entities.each do |entity|
+          next if entity_ids.include?(entity.persistent_id)
+
+          entity.hidden = true
+        end
+
+        Events::SelectionEventAction.update_state(state, { clear: true })
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/select_mappings_from_table.rb
+++ b/speckle_connector/src/actions/select_mappings_from_table.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+require_relative 'events/selection_event_action'
+require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  module Actions
+    # Select entities that selected from mapped elements table.
+    class SelectMappingsFromTable < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, data)
+        # Clear first selection
+        state.sketchup_state.sketchup_model.selection.clear
+
+        # Flat entities to clear mappings
+        flat_entities = SketchupModel::Query::Entity.flat_entities(state.sketchup_state.sketchup_model.entities)
+
+        # Collect entity ids to clear mappings
+        entity_ids = data.collect { |_, entities| entities['selectedElements'].collect { |e| e['entityId'] } }.flatten
+
+        # Store speckle state to update with mapped entities.
+        flat_entities.each do |entity|
+          next unless entity_ids.include?(entity.persistent_id)
+
+          state.sketchup_state.sketchup_model.selection.add(entity)
+        end
+
+        Events::SelectionEventAction.update_state(state, { clear: true })
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/show_all_entities.rb
+++ b/speckle_connector/src/actions/show_all_entities.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module SpeckleConnector
+  module Actions
+    # Show all entities on the model.
+    class ShowAllEntities < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, _data)
+        # Show all entities first
+        state.sketchup_state.sketchup_model.entities.each do |ent|
+          ent.hidden = false
+        end
+        state
+      end
+    end
+  end
+end

--- a/speckle_connector/src/sketchup_model/query/entity.rb
+++ b/speckle_connector/src/sketchup_model/query/entity.rb
@@ -33,7 +33,10 @@ module SpeckleConnector
           # @example
           #   path[0] is entity itself
           #   path[1..-1] rest as path from top to bottom
-          def flat_entities_with_path(entities_to_flat, classes, path = [])
+          def flat_entities_with_path(entities_to_flat,
+                                      classes = [Sketchup::Edge, Sketchup::Face, Sketchup::ComponentInstance,
+                                                 Sketchup::Group, Sketchup::ComponentDefinition],
+                                      path = [])
             entities = []
             entities_to_flat.each do |entity|
               # Collect object itself

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -84,13 +84,17 @@ module SpeckleConnector
         end
 
         def self.entity_selection_details(entity)
+          sanitized_type = entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split
+          is_definition = entity.is_a?(Sketchup::ComponentDefinition)
+          entity_type = is_definition ? sanitized_type.last : sanitized_type.first
           speckle_schema = get_schema(entity)
           {
             name: speckle_schema['name'],
             entityName: entity.respond_to?(:name) ? entity.name : '',
             entityId: entity.persistent_id,
-            entityType: entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split.last,
-            schema: speckle_schema
+            entityType: entity_type,
+            schema: speckle_schema,
+            numberOfInstances: is_definition ? entity.instances.length : 1
           }
         end
 

--- a/speckle_connector/src/ui/vue_view.rb
+++ b/speckle_connector/src/ui/vue_view.rb
@@ -24,6 +24,10 @@ require_relative '../actions/collect_preferences'
 require_relative '../actions/deactivate_diffing'
 require_relative '../actions/collect_versions'
 require_relative '../actions/mapped_entities_updated'
+require_relative '../actions/clear_mappings_from_table'
+require_relative '../actions/isolate_mappings_from_table'
+require_relative '../actions/hide_mappings_from_table'
+require_relative '../actions/select_mappings_from_table'
 
 module SpeckleConnector
   module Ui
@@ -76,9 +80,13 @@ module SpeckleConnector
           model_preferences_updated: Commands::ModelPreferencesUpdated.new(@app),
           activate_diffing: Commands::ActivateDiffing.new(@app),
           deactivate_diffing: Commands::ActionCommand.new(@app, Actions::DeactivateDiffing),
+          collect_mapped_entities: Commands::ActionCommand.new(@app, Actions::MappedEntitiesUpdated),
           apply_mappings: Commands::ApplyMappings.new(@app),
           clear_mappings: Commands::ClearMappings.new(@app),
-          collect_mapped_entities: Commands::ActionCommand.new(@app, Actions::MappedEntitiesUpdated)
+          clear_mappings_from_table: Commands::ActionCommand.new(@app, Actions::ClearMappingsFromTable),
+          isolate_mappings_from_table: Commands::ActionCommand.new(@app, Actions::IsolateMappingsFromTable),
+          hide_mappings_from_table: Commands::ActionCommand.new(@app, Actions::HideMappingsFromTable),
+          select_mappings_from_table: Commands::ActionCommand.new(@app, Actions::SelectMappingsFromTable)
         }.freeze
       end
     end

--- a/speckle_connector/src/ui/vue_view.rb
+++ b/speckle_connector/src/ui/vue_view.rb
@@ -28,6 +28,7 @@ require_relative '../actions/clear_mappings_from_table'
 require_relative '../actions/isolate_mappings_from_table'
 require_relative '../actions/hide_mappings_from_table'
 require_relative '../actions/select_mappings_from_table'
+require_relative '../actions/show_all_entities'
 
 module SpeckleConnector
   module Ui
@@ -86,7 +87,8 @@ module SpeckleConnector
           clear_mappings_from_table: Commands::ActionCommand.new(@app, Actions::ClearMappingsFromTable),
           isolate_mappings_from_table: Commands::ActionCommand.new(@app, Actions::IsolateMappingsFromTable),
           hide_mappings_from_table: Commands::ActionCommand.new(@app, Actions::HideMappingsFromTable),
-          select_mappings_from_table: Commands::ActionCommand.new(@app, Actions::SelectMappingsFromTable)
+          select_mappings_from_table: Commands::ActionCommand.new(@app, Actions::SelectMappingsFromTable),
+          show_all_entities: Commands::ActionCommand.new(@app, Actions::ShowAllEntities)
         }.freeze
       end
     end

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,7 +20,7 @@
         "vue-apollo": "^3.0.0-beta.11",
         "vue-router": "^3.2.0",
         "vue-timeago": "^5.1.3",
-        "vuetify": "^2.4.0"
+        "vuetify": "2.6.10"
       },
       "devDependencies": {
         "@vue/cli-plugin-babel": "~4.5.0",
@@ -25264,9 +25264,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.6.tgz",
-      "integrity": "sha512-H4KtxDFmDN8QiTRiGfBySyjMhVaHAJTKB0llGGKZT5jKxtnx9gvEtMWXKtVuRP0NJJP0H6xBPJHNOH7nT18qiQ==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.10.tgz",
+      "integrity": "sha512-fgUeRDDCwYkwu6WGEEKGe7IdfzOsXJCZGrqkn1pcS2ycuoDL8mR2/dejH5iFNnBY6MnsT365PAGn0J+9otjfQg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -46606,9 +46606,9 @@
       }
     },
     "vuetify": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.6.tgz",
-      "integrity": "sha512-H4KtxDFmDN8QiTRiGfBySyjMhVaHAJTKB0llGGKZT5jKxtnx9gvEtMWXKtVuRP0NJJP0H6xBPJHNOH7nT18qiQ==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.10.tgz",
+      "integrity": "sha512-fgUeRDDCwYkwu6WGEEKGe7IdfzOsXJCZGrqkn1pcS2ycuoDL8mR2/dejH5iFNnBY6MnsT365PAGn0J+9otjfQg==",
       "requires": {}
     },
     "vuetify-loader": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "vue-apollo": "^3.0.0-beta.11",
     "vue-router": "^3.2.0",
     "vue-timeago": "^5.1.3",
-    "vuetify": "^2.4.0"
+    "vuetify": "2.6.10"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -1,0 +1,105 @@
+<template>
+  <v-data-table
+      class="elevation-1"
+      dense
+      expand
+      disable-filtering
+      disable-pagination
+      hide-default-footer
+      item-key="categoryName"
+      :expanded.sync="mappedElementsExpandedIndexes"
+      :headers="mappedElementsHeaders"
+      :items="mappedEntitiesTableData"
+      :mobile-breakpoint="0"
+  >
+    <template v-slot:expanded-item="{ headers, item }">
+      <td :colspan="headers.length" class="pl-2 pr-0">
+        <v-data-table
+            class="elevation-0 pa-0 ma-0"
+            dense
+            disable-filtering
+            disable-pagination
+            hide-default-footer
+            item-key="entityId"
+            :headers="subMappedElementsHeaders"
+            :items="item.entities"
+            :mobile-breakpoint="0"
+        >
+        </v-data-table>
+      </td>
+    </template>
+    <template v-slot:item.categoryName="slotData">
+      <div @click="clickMappedElementsColumn(slotData)">{{ slotData.item.categoryName }}</div>
+    </template>
+  </v-data-table>
+</template>
+
+<script>
+/*global sketchup*/
+import {bus} from "@/main";
+import {groupBy} from "@/utils/groupBy";
+
+export default {
+  name: "MappedElements",
+  data(){
+    return {
+      mappedEntities: [],
+      mappedEntityCount: 0,
+      // Expanded indexes for mapped element table (Categories)
+      mappedElementsExpandedIndexes: [],
+      mappedElementsHeaders: [
+        { text: 'Category', sortable: false, value: 'categoryName', width: '80%' },
+        { text: 'Count', sortable: false, align: 'center', value: 'count', width: '20%' }
+      ],
+      subMappedElementsHeaders: [
+        { text: 'Type', sortable: false, value: 'entityType', width: '80%' },
+        { text: 'Name/Id', sortable: false, align: 'center', value: 'nameOrId', width: '20%' },
+      ],
+      mappedEntitiesTableData: [],
+    }
+  },
+  mounted() {
+    sketchup.exec({name: "collect_mapped_entities", data: {}})
+
+    bus.$on('mapped-entities-updated', async (mappedEntities) => {
+      this.mappedEntityCount = mappedEntities.length
+      this.mappedEntities = mappedEntities
+      this.getMappedElementsTableData()
+    })
+  },
+  methods: {
+    clickMappedElementsColumn(slotData) {
+      const indexExpanded = this.mappedElementsExpandedIndexes.findIndex(i => i === slotData.item);
+      if (indexExpanded > -1) {
+        this.mappedElementsExpandedIndexes.splice(indexExpanded, 1)
+      } else {
+        this.mappedElementsExpandedIndexes.push(slotData.item);
+      }
+    },
+    getMappedElementsTableData(){
+      let groupByCategoryName = groupBy('categoryName')
+      let groupedByCategoryName = groupByCategoryName(this.mappedEntities)
+      this.mappedEntitiesTableData = Object.entries(groupedByCategoryName).map(
+          (entry) => {
+            const [categoryName, entities] = entry
+            return {
+              'categoryName': categoryName,
+              'count': entities !== true ? entities.length : 0,
+              'entities': entities.map((entity) => {
+                return {
+                  'entityId': entity['entityId'],
+                  'nameOrId': entity['name'] !== "" ? entity['name'] : entity['entityId'],
+                  'entityType': entity['entityType']
+                }
+              })
+            }
+          }
+      )
+    },
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container class="pa-0">
     <v-data-table
-        :v-model="categorySelection()"
-        class="elevation-1 mb-5"
+        v-model="categorySelection"
+        class="elevation-1 mb-2"
         dense
         expand
         disable-filtering
@@ -94,7 +94,7 @@
       </template>
 
     </v-data-table>
-      <v-container class="btn-container">
+      <v-container class="btn-container px-0">
         <v-btn
           v-tooltip="'Clear Mappings'"
           x-small
@@ -102,9 +102,10 @@
           min-height="30px"
           @click="clearMappingsFromTableSelection"
         >
-          <v-icon small dark>
+          <v-icon left dark>
               mdi-delete
           </v-icon>
+            Clear
         </v-btn>
 
         <v-spacer></v-spacer>
@@ -117,22 +118,24 @@
           class="mr-2"
           @click="isolateMappedElementsOnSketchup"
         >
-          <v-icon small dark>
-            mdi-cube-outline
+          <v-icon left dark>
+              mdi-arrange-bring-forward
           </v-icon>
+            Isolate
         </v-btn>
 
         <v-btn
-          v-tooltip="'Show Mapped Elements'"
+          v-tooltip="'Hide Mapped Elements'"
           x-small
           min-width="30px"
           min-height="30px"
           class="mr-2"
-          @click="showMappedElementsOnSketchup"
+          @click="hideMappedElementsOnSketchup"
         >
-          <v-icon small dark>
-            mdi-eye
+          <v-icon left dark>
+            mdi-eye-off
           </v-icon>
+            Hide
         </v-btn>
 
         <v-btn
@@ -142,9 +145,10 @@
           min-height="30px"
           @click="selectMappedElementsOnSketchup"
         >
-          <v-icon small dark>
-            mdi-cursor-default
+          <v-icon left dark>
+              mdi-select-all
           </v-icon>
+            Select
         </v-btn>
       </v-container>
   </v-container>
@@ -176,9 +180,9 @@ export default {
     }
   },
   computed: {
-    // categorySelection() {
-    //     return Object.keys(this.elementSelection)
-    // },
+    categorySelection() {
+        return Object.keys(this.elementSelection)
+    },
   },
   mounted() {
     sketchup.exec({name: "collect_mapped_entities", data: {}})
@@ -190,9 +194,9 @@ export default {
     })
   },
   methods: {
-    categorySelection() {
-        return Object.keys(this.elementSelection)
-    },
+    // categorySelection() {
+    //     return Object.keys(this.elementSelection)
+    // },
     clickMappedElementsCategory(slotData) {
       const indexExpanded = this.mappedElementsExpandedIndexes.findIndex(i => i === slotData.item);
       if (indexExpanded > -1) {
@@ -226,16 +230,16 @@ export default {
         // }
     },
     clearMappingsFromTableSelection(){
-        sketchup.exec({ name: "clearMappingsFromTable", data: this.elementSelection })
+        sketchup.exec({ name: "clear_mappings_from_table", data: this.elementSelection })
     },
     isolateMappedElementsOnSketchup(){
-        sketchup.exec({ name: "isolateMappingsFromTable", data: this.elementSelection })
+        sketchup.exec({ name: "isolate_mappings_from_table", data: this.elementSelection })
     },
-    showMappedElementsOnSketchup(){
-        sketchup.exec({ name: "showMappingsFromTable", data: this.elementSelection })
+    hideMappedElementsOnSketchup(){
+        sketchup.exec({ name: "hide_mappings_from_table", data: this.elementSelection })
     },
     selectMappedElementsOnSketchup(){
-        sketchup.exec({ name: "selectMappingsFromTable", data: this.elementSelection })
+        sketchup.exec({ name: "select_mappings_from_table", data: this.elementSelection })
     },
     getMappedElementsTableData(){
       let groupByCategoryName = groupBy('categoryName')

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -1,37 +1,44 @@
 <template>
-  <v-data-table
-      class="elevation-1"
-      dense
-      expand
-      disable-filtering
-      disable-pagination
-      hide-default-footer
-      item-key="categoryName"
-      :expanded.sync="mappedElementsExpandedIndexes"
-      :headers="mappedElementsHeaders"
-      :items="mappedEntitiesTableData"
-      :mobile-breakpoint="0"
-  >
-    <template v-slot:expanded-item="{ headers, item }">
-      <td :colspan="headers.length" class="pl-2 pr-0">
-        <v-data-table
-            class="elevation-0 pa-0 ma-0"
-            dense
-            disable-filtering
-            disable-pagination
-            hide-default-footer
-            item-key="entityId"
-            :headers="subMappedElementsHeaders"
-            :items="item.entities"
-            :mobile-breakpoint="0"
-        >
-        </v-data-table>
-      </td>
-    </template>
-    <template v-slot:item.categoryName="slotData">
-      <div @click="clickMappedElementsColumn(slotData)">{{ slotData.item.categoryName }}</div>
-    </template>
-  </v-data-table>
+  <v-container class="pa-0">
+    <v-data-table
+        class="elevation-1 mb-5"
+        dense
+        expand
+        disable-filtering
+        disable-pagination
+        hide-default-footer
+        item-key="categoryName"
+        :expanded.sync="mappedElementsExpandedIndexes"
+        :headers="mappedElementsHeaders"
+        :items="mappedEntitiesTableData"
+        :mobile-breakpoint="0"
+        show-select
+    >
+      <template v-slot:expanded-item="{ headers, item }">
+        <td :colspan="headers.length" class="pl-2 pr-0">
+          <v-data-table
+              class="elevation-0 pa-0 ma-0"
+              dense
+              disable-filtering
+              disable-pagination
+              hide-default-footer
+              item-key="entityId"
+              :headers="subMappedElementsHeaders"
+              :items="item.entities"
+              :mobile-breakpoint="0"
+          >
+          </v-data-table>
+        </td>
+      </template>
+      <template v-slot:item.categoryName="slotData">
+        <div @click="clickMappedElementsColumn(slotData)">{{ slotData.item.categoryName }}</div>
+      </template>
+    </v-data-table>
+
+    <v-btn>
+      test
+    </v-btn>
+  </v-container>
 </template>
 
 <script>
@@ -101,5 +108,12 @@ export default {
 </script>
 
 <style scoped>
+.btn-container{
+  display: flex;
+  flex-wrap: wrap;
+}
 
+.v-input--selection-controls__input{
+  margin-right: 0px;
+}
 </style>

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -1,6 +1,7 @@
 <template>
   <v-container class="pa-0">
     <v-data-table
+        v-model="categorySelection"
         class="elevation-1 mb-5"
         dense
         expand
@@ -15,29 +16,106 @@
         show-select
     >
       <template v-slot:expanded-item="{ headers, item }">
-        <td :colspan="headers.length" class="pl-2 pr-0">
+        <td :colspan="headers.length" class="pl-2 pr-0 lighten-3 grey">
           <v-data-table
+              v-model="elementSelection"
               class="elevation-0 pa-0 ma-0"
               dense
               disable-filtering
               disable-pagination
               hide-default-footer
+              hide-default-header
               item-key="entityId"
               :headers="subMappedElementsHeaders"
               :items="item.entities"
               :mobile-breakpoint="0"
+              show-select
           >
+            <template #[`item.data-table-select`]="slotData">
+                <td class="mapped-elements-check-box-row">
+                    <v-checkbox
+                            class="shrink ma-0"
+                            hide-details
+                            :value="slotData.isSelected"
+                            @click="slotData.select(clickMappedElements(slotData, item.categoryName))"
+                    />
+                </td>
+            </template>
           </v-data-table>
         </td>
       </template>
-      <template v-slot:item.categoryName="slotData">
-        <div @click="clickMappedElementsColumn(slotData)">{{ slotData.item.categoryName }}</div>
-      </template>
-    </v-data-table>
 
-    <v-btn>
-      test
-    </v-btn>
+      <template #[`header.name`]="{ header }">
+          <th class="header-text-color">{{ header.text.toUpperCase() }}</th>
+      </template>
+
+      <template #[`item.categoryName`]="slotData">
+        <div @click="clickMappedElementsCategory(slotData)">{{ slotData.item.categoryName }}</div>
+      </template>
+
+      <template #[`item.data-table-select`]="slotData">
+        <v-checkbox
+                class="shrink ma-0"
+                hide-details
+                :value="slotData.isSelected"
+                @click="slotData.select(clickMappedCategory(slotData))"
+        />
+      </template>
+
+    </v-data-table>
+      <v-container class="btn-container">
+        <v-btn
+          v-tooltip="'Clear Mappings'"
+          x-small
+          min-width="30px"
+          min-height="30px"
+          @click="clearMappingsFromTableSelection"
+        >
+          <v-icon small dark>
+              mdi-delete
+          </v-icon>
+        </v-btn>
+
+        <v-spacer></v-spacer>
+
+        <v-btn
+          v-tooltip="'Isolate Mapped Elements'"
+          x-small
+          min-width="30px"
+          min-height="30px"
+          class="mr-2"
+          @click="isolateMappedElementsOnSketchup"
+        >
+          <v-icon small dark>
+            mdi-cube-outline
+          </v-icon>
+        </v-btn>
+
+        <v-btn
+          v-tooltip="'Show Mapped Elements'"
+          x-small
+          min-width="30px"
+          min-height="30px"
+          class="mr-2"
+          @click="showMappedElementsOnSketchup"
+        >
+          <v-icon small dark>
+            mdi-eye
+          </v-icon>
+        </v-btn>
+
+        <v-btn
+          v-tooltip="'Select Mapped Elements'"
+          x-small
+          min-width="30px"
+          min-height="30px"
+          @click="selectMappedElementsOnSketchup"
+        >
+          <v-icon small dark>
+            mdi-cursor-default
+          </v-icon>
+        </v-btn>
+      </v-container>
   </v-container>
 </template>
 
@@ -50,17 +128,19 @@ export default {
   name: "MappedElements",
   data(){
     return {
+      categorySelection: [],
+      elementSelection: [],
       mappedEntities: [],
       mappedEntityCount: 0,
       // Expanded indexes for mapped element table (Categories)
       mappedElementsExpandedIndexes: [],
       mappedElementsHeaders: [
-        { text: 'Category', sortable: false, value: 'categoryName', width: '80%' },
-        { text: 'Count', sortable: false, align: 'center', value: 'count', width: '20%' }
+        { text: 'Category', sortable: false, value: 'categoryName', width: '70%' },
+        { text: 'Count', sortable: false, align: 'center', value: 'count', width: '30%' }
       ],
       subMappedElementsHeaders: [
-        { text: 'Type', sortable: false, value: 'entityType', width: '80%' },
-        { text: 'Name/Id', sortable: false, align: 'center', value: 'nameOrId', width: '20%' },
+        { text: 'Type', sortable: false, value: 'entityType', width: '70%' },
+        { text: 'Name/Id', sortable: false, align: 'center', value: 'nameOrId', width: '30%' },
       ],
       mappedEntitiesTableData: [],
     }
@@ -75,7 +155,7 @@ export default {
     })
   },
   methods: {
-    clickMappedElementsColumn(slotData) {
+    clickMappedElementsCategory(slotData) {
       const indexExpanded = this.mappedElementsExpandedIndexes.findIndex(i => i === slotData.item);
       if (indexExpanded > -1) {
         this.mappedElementsExpandedIndexes.splice(indexExpanded, 1)
@@ -83,24 +163,56 @@ export default {
         this.mappedElementsExpandedIndexes.push(slotData.item);
       }
     },
+    clickMappedElements(slotData, category){
+        const indexSelection = this.elementSelection.findIndex(i => i === slotData.item);
+        if (indexSelection > -1) {
+            this.elementSelection.splice(indexSelection, 1)
+        } else {
+            this.elementSelection.push(slotData.item);
+        }
+        console.log(category)
+        console.log(slotData)
+        console.log(this.elementSelection)
+    },
+    clickMappedCategory(slotData){
+        const indexSelection = this.categorySelection.findIndex(i => i === slotData.item);
+        if (indexSelection > -1) {
+            this.categorySelection.splice(indexSelection, 1)
+        } else {
+            this.categorySelection.push(slotData.item);
+        }
+        console.log(this.categorySelection)
+    },
+    clearMappingsFromTableSelection(){
+
+    },
+    isolateMappedElementsOnSketchup(){
+
+    },
+    showMappedElementsOnSketchup(){
+
+    },
+    selectMappedElementsOnSketchup(){
+
+    },
     getMappedElementsTableData(){
       let groupByCategoryName = groupBy('categoryName')
       let groupedByCategoryName = groupByCategoryName(this.mappedEntities)
       this.mappedEntitiesTableData = Object.entries(groupedByCategoryName).map(
-          (entry) => {
-            const [categoryName, entities] = entry
-            return {
-              'categoryName': categoryName,
-              'count': entities !== true ? entities.length : 0,
-              'entities': entities.map((entity) => {
-                return {
-                  'entityId': entity['entityId'],
-                  'nameOrId': entity['name'] !== "" ? entity['name'] : entity['entityId'],
-                  'entityType': entity['entityType']
-                }
-              })
-            }
+        (entry) => {
+          const [categoryName, entities] = entry
+          return {
+            'categoryName': categoryName,
+            'count': entities !== true ? entities.length : 0,
+            'entities': entities.map((entity) => {
+              return {
+                'entityId': entity['entityId'],
+                'nameOrId': entity['name'] !== "" ? entity['name'] : entity['entityId'],
+                'entityType': entity['entityType']
+              }
+            })
           }
+        }
       )
     },
   }
@@ -113,7 +225,16 @@ export default {
   flex-wrap: wrap;
 }
 
-.v-input--selection-controls__input{
-  margin-right: 0px;
+.v-application--is-ltr .v-input--selection-controls__input{
+  margin-right: 0;
 }
+
+.header-text-color{
+    color: red;
+}
+
+.mapped-elements-check-box-row {
+    width: 20px;
+}
+
 </style>

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -16,10 +16,10 @@
         show-select
     >
       <template v-slot:expanded-item="{ headers, item }">
-        <td :colspan="headers.length" class="pl-2 pr-0 lighten-3 grey">
+        <td :colspan="headers.length" class="pl-2 pr-0">
           <v-data-table
               v-model="elementSelection[item.categoryName]['selectedElements']"
-              class="elevation-0 pa-0 ma-0"
+              class="elevation-0 pa-0 ma-0 mb-2"
               dense
               disable-filtering
               disable-pagination
@@ -31,6 +31,21 @@
               :mobile-breakpoint="0"
               show-select
           >
+              <template #header="{ props: { headers } }">
+                  <thead class="v-data-table-header">
+                  <tr>
+                      <th
+                              v-for="header in headers"
+                              :key="header.value"
+                              :width="header.width"
+                              scope="col"
+                              class="text-center"
+                      >
+                          {{ header.text }}
+                      </th>
+                  </tr>
+                  </thead>
+              </template>
             <template #[`item.data-table-select`]="slotData">
                 <td class="mapped-elements-check-box-row">
                     <v-checkbox
@@ -134,11 +149,11 @@ export default {
       // Expanded indexes for mapped element table (Categories)
       mappedElementsExpandedIndexes: [],
       mappedElementsHeaders: [
-        { text: 'Category', sortable: false, value: 'categoryName', width: '70%' },
+        { text: 'Category', sortable: false, align: 'center', value: 'categoryName', width: '70%' },
         { text: 'Count', sortable: false, align: 'center', value: 'count', width: '30%' }
       ],
       subMappedElementsHeaders: [
-        { text: 'Type', sortable: false, value: 'entityType', width: '70%' },
+        { text: 'Type', sortable: false, align: 'center', value: 'entityType', width: '70%' },
         { text: 'Name/Id', sortable: false, align: 'center', value: 'nameOrId', width: '30%' },
       ],
       mappedEntitiesTableData: [],
@@ -235,16 +250,13 @@ export default {
   flex-wrap: wrap;
 }
 
-.v-application--is-ltr .v-input--selection-controls__input{
-  margin-right: 0;
-}
-
-.header-text-color{
-    color: red;
-}
-
 .mapped-elements-check-box-row {
     width: 20px;
+}
+
+/* This is the header styles of child table */
+.v-data-table--dense > .v-data-table__wrapper > table > thead > tr > th {
+    height: 32px;
 }
 
 </style>

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -111,7 +111,7 @@
         <v-spacer></v-spacer>
 
         <v-btn
-          v-tooltip="'Isolate Mapped Elements'"
+          v-tooltip=" isIsolated ? 'Show All Elements' : 'Isolate Mapped Elements'"
           x-small
           min-width="30px"
           min-height="30px"
@@ -119,9 +119,9 @@
           @click="isolateMappedElementsOnSketchup"
         >
           <v-icon left dark>
-              mdi-arrange-bring-forward
+              {{ isIsolated ? 'mdi-crop-rotate' : 'mdi-crop'}}
           </v-icon>
-            Isolate
+          {{ isIsolated ? 'Show All' : 'Isolate'}}
         </v-btn>
 
         <v-btn
@@ -163,6 +163,7 @@ export default {
   name: "MappedElements",
   data(){
     return {
+      isIsolated: false,
       elementSelection: {},
       mappedEntities: [],
       mappedEntityCount: 0,
@@ -233,7 +234,13 @@ export default {
         sketchup.exec({ name: "clear_mappings_from_table", data: this.elementSelection })
     },
     isolateMappedElementsOnSketchup(){
+      if (this.isIsolated){
+        this.isIsolated = false
+        sketchup.exec({ name: "show_all_entities", data: {} })
+      } else {
+        this.isIsolated = true
         sketchup.exec({ name: "isolate_mappings_from_table", data: this.elementSelection })
+      }
     },
     hideMappedElementsOnSketchup(){
         sketchup.exec({ name: "hide_mappings_from_table", data: this.elementSelection })

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -190,7 +190,7 @@
             {{ `Mapped Elements (${mappedEntityCount})` }}
           </div>
         </v-expansion-panel-header>
-        <v-expansion-panel-content>
+        <v-expansion-panel-content class="mx-n3">
           <mapped-elements/>
         </v-expansion-panel-content>
       </v-expansion-panel>

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -71,7 +71,7 @@
           <v-container v-if="entitySelected" class="btn-container pa-0 mb-5">
             <v-card
                 variant="outlined"
-                class="pt-0 pl-2 mb-1 mr-2 v-alert--border flex"
+                class="pt-0 pl-2 mb-1 mr-2 flex"
                 :elevation="entityCardElevation"
                 :outlined="!definitionSelected"
                 :width="entityCardWidth"
@@ -96,9 +96,10 @@
             <v-card
                 v-if=selectedEntitiesHasParent
                 variant="outlined"
+                class="pt-0 pl-2 mb-1 mr-2 flex"
                 :elevation="definitionSelected ? '6' : '1'"
                 :outlined="definitionSelected"
-                class="pt-0 pl-2 mb-1 mr-2 flex"
+                :width="entityCardWidth"
                 min-width="150px"
                 @click="definitionSelectedHandler(true)"
             >
@@ -152,7 +153,6 @@
             <v-row justify="center" align="center">
               <v-col cols="auto" class="pa-1 pb-2">
                 <v-btn
-                    class="pt-1"
                     :disabled="!entitySelected"
                     @click="applyMapping"
                 >
@@ -163,7 +163,6 @@
               </v-col>
               <v-col cols="auto" class="pa-1 pb-2">
                 <v-btn
-                    class="pt-1"
                     :disabled="!entitySelected"
                     @click="clearMapping"
                 >

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -191,39 +191,7 @@
           </div>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          <v-data-table
-              class="elevation-1"
-              dense
-              expand
-              disable-filtering
-              disable-pagination
-              hide-default-footer
-              item-key="categoryName"
-              :expanded.sync="mappedElementsExpandedIndexes"
-              :headers="mappedElementsHeaders"
-              :items="mappedEntitiesTableData"
-              :mobile-breakpoint="0"
-          >
-            <template v-slot:expanded-item="{ headers, item }">
-              <td :colspan="headers.length" class="pl-2 pr-0">
-                <v-data-table
-                    class="elevation-0 pa-0 ma-0"
-                    dense
-                    disable-filtering
-                    disable-pagination
-                    hide-default-footer
-                    item-key="entityId"
-                    :headers="subMappedElementsHeaders"
-                    :items="item.entities"
-                    :mobile-breakpoint="0"
-                >
-                </v-data-table>
-              </td>
-            </template>
-            <template v-slot:item.categoryName="slotData">
-              <div @click="clickMappedElementsColumn(slotData)">{{ slotData.item.categoryName }}</div>
-            </template>
-          </v-data-table>
+          <mapped-elements/>
         </v-expansion-panel-content>
       </v-expansion-panel>
 
@@ -253,7 +221,8 @@ global.mappedEntitiesUpdated = function (mappedEntities) {
 export default {
   name: "Mapper",
   components: {
-    GlobalToast: () => import('@/components/GlobalToast')
+    GlobalToast: () => import('@/components/GlobalToast'),
+    MappedElements: () => import('@/components/MappedElements.vue')
   },
   data() {
     return {
@@ -397,26 +366,6 @@ export default {
       this.selectedCategory = null
       this.entityMapped = false
       this.definitionMapped = false
-    },
-    getMappedElementsTableData(){
-      let groupByCategoryName = groupBy('categoryName')
-      let groupedByCategoryName = groupByCategoryName(this.mappedEntities)
-      this.mappedEntitiesTableData = Object.entries(groupedByCategoryName).map(
-          (entry) => {
-            const [categoryName, entities] = entry
-            return {
-              'categoryName': categoryName,
-              'count': entities !== true ? entities.length : 0,
-              'entities': entities.map((entity) => {
-                return {
-                  'entityId': entity['entityId'],
-                  'nameOrId': entity['name'] !== "" ? entity['name'] : entity['entityId'],
-                  'entityType': entity['entityType']
-                }
-              })
-            }
-          }
-      )
     },
     getSelectionTableData(){
       let groupByClass = groupBy('entityType')
@@ -588,8 +537,6 @@ export default {
     })
     bus.$on('mapped-entities-updated', async (mappedEntities) => {
       this.mappedEntityCount = mappedEntities.length
-      this.mappedEntities = mappedEntities
-      this.getMappedElementsTableData()
     })
   }
 }

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -463,26 +463,41 @@ export default {
       }
       if (this.definitionSelected) {
         if (!this.definitionMapped){
-          this.name = this.lastSelectedEntity['definition']['entityName']
+          if (this.selectedEntityCount > 1){
+            this.name = '<Mixed>'
+          }else{
+            this.name = this.lastSelectedEntity['definition']['entityName']
+          }
           this.selectedMethod = 'Direct Shape'
           this.selectedCategory = 49
-          return
+        } else {
+          if (this.selectedEntityCount > 1){
+            this.name = '<Mixed>'
+          }else{
+            this.name = this.lastSelectedEntity['definition']['schema']['name']
+          }
+          this.selectedMethod = this.lastSelectedEntity['definition']['schema']['method']
+          this.selectedCategory = this.lastSelectedEntity['definition']['schema']['category']
         }
-        this.selectedMethod = this.lastSelectedEntity['definition']['schema']['method']
-        this.selectedCategory = this.lastSelectedEntity['definition']['schema']['category']
-        this.name = this.lastSelectedEntity['definition']['schema']['name']
       } else {
         if (!this.entityMapped){
-          this.name = this.lastSelectedEntity['entityName']
+          if (this.selectedEntityCount > 1){
+            this.name = '<Mixed>'
+          }else{
+            this.name = this.lastSelectedEntity['entityName']
+          }
           this.selectedMethod = 'Direct Shape'
           this.selectedCategory = 49
-          return
+        } else {
+          if (this.selectedEntityCount > 1){
+            this.name = '<Mixed>'
+          }else{
+            this.name = this.lastSelectedEntity['schema']['name']
+          }
+          this.selectedMethod = this.lastSelectedEntity['schema']['method']
+          this.selectedCategory = this.lastSelectedEntity['schema']['category']
         }
-        this.selectedMethod = this.lastSelectedEntity['schema']['method']
-        this.selectedCategory = this.lastSelectedEntity['schema']['category']
-        this.name = this.lastSelectedEntity['schema']['name']
       }
-
     },
     isEntityMapped(entity){
       return entity['schema']['category'] !== undefined

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -71,13 +71,14 @@
           <v-container v-if="entitySelected" class="btn-container pa-0 mb-5">
             <v-card
                 variant="outlined"
-                class="pt-1 pl-2 mb-1 mr-2 v-alert--border flex"
+                class="pt-0 pl-2 mb-1 mr-2 v-alert--border flex"
                 :elevation="entityCardElevation"
                 :outlined="!definitionSelected"
                 :width="entityCardWidth"
+                min-width="150px"
                 @click="definitionSelectedHandler(false)"
             >
-              <v-card-title class="pa-0 pb-3">
+              <v-card-title class="pa-0 pb-2">
                 <v-icon class="mr-1 v-bottom-navigation--absolute">
                   {{ getSelectedEntityIcon }}
                 </v-icon>
@@ -87,10 +88,9 @@
                   mdi-checkbox-marked-circle
                 </v-icon>
               </v-card-title>
-              <v-card-subtitle class="text-sm-subtitle-2 pb-1 pr-0 font-weight-light">
+              <v-card-subtitle class="pb-0 pr-0 font-weight-light">
                 {{getSelectedEntitySubText}}
               </v-card-subtitle>
-
             </v-card>
 
             <v-card
@@ -98,11 +98,11 @@
                 variant="outlined"
                 :elevation="definitionSelected ? '6' : '1'"
                 :outlined="definitionSelected"
-                class="pt-1 pl-2 mb-1 mr-2 flex"
-                width="160px"
+                class="pt-0 pl-2 mb-1 mr-2 flex"
+                min-width="150px"
                 @click="definitionSelectedHandler(true)"
             >
-              <v-card-title class="pa-0 pb-3">
+              <v-card-title class="pa-0 pb-2">
                 <v-icon class="mr-1">
                   mdi-atom
                 </v-icon>
@@ -112,8 +112,8 @@
                   mdi-checkbox-marked-circle
                 </v-icon>
               </v-card-title>
-              <v-card-subtitle class="text-sm-subtitle-2 pb-1 pr-0 font-weight-light">
-                Instance definition
+              <v-card-subtitle class="pb-0 pr-0 font-weight-light">
+                {{getSelectedDefinitionSubText}}
               </v-card-subtitle>
             </v-card>
           </v-container>
@@ -263,9 +263,9 @@ export default {
       mappedElementsExpandedIndexes: [],
       // Whether definition card is selected to map or not.
       definitionSelected: false,
-      // Initial entity (Group, Instance, Face, Edge) that mapped or not
+      // Initial entity (Group, Component, Face, Edge) that mapped or not
       entityMapped: false,
-      // Definition of entity is mapped, it will be available for only Instances.
+      // Definition of entity is mapped, it will be available for only Components.
       definitionMapped: false,
       // Whether an entity is selected or not.
       entitySelected: false,
@@ -303,16 +303,16 @@ export default {
   },
   computed:{
     lastSelectedEntityHasParent(){
-      return this.lastSelectedEntity['entityType'] === 'Instance'
+      return this.lastSelectedEntity['entityType'] === 'Component'
     },
     selectedEntitiesHasParent(){
-      return this.selectedEntities.every((entity) => entity['entityType'] === 'Instance')
+      return this.selectedEntities.every((entity) => entity['entityType'] === 'Component')
     },
     entityCardWidth(){
       if (this.lastSelectedEntityHasParent){
-        return '160px'
+        return '150px'
       } else {
-        return '330px'
+        return '310px'
       }
     },
     entityCardElevation(){
@@ -338,7 +338,7 @@ export default {
           return 'mdi-vector-polyline'
         } else if (type === 'Group'){
           return 'mdi-border-outside'
-        } else if (type === 'Instance'){
+        } else if (type === 'Component'){
           return 'mdi-border-inside'
         } else {
           return 'mdi-close'
@@ -348,7 +348,7 @@ export default {
     getSelectedEntityText(){
       if (this.selectedEntities.length > 1){
         if (this.selectedEntitiesHasParent){
-          return 'Instances'
+          return 'Component'
         }
         return 'Multiple Selection'
       }else{
@@ -357,7 +357,7 @@ export default {
     },
     getSelectedDefinitionText(){
       if (this.selectedEntities.length > 1 && this.selectedEntitiesHasParent){
-        return 'Definitions'
+        return 'Definition'
       }else{
         return 'Definition'
       }
@@ -366,8 +366,23 @@ export default {
       if (this.selectedEntities.length > 1){
         return this.getSelectionSummary()
       }else{
-        return 'Last selected entity'
+        return 'Single selected entity'
       }
+    },
+    getSelectedDefinitionSubText(){
+        if (this.selectedEntities.length > 1){
+            let instances = 0
+            let registeredDefinitions = []
+            this.selectedEntities.forEach((entity) => {
+                if (!registeredDefinitions.includes(entity['definition']['entityId'])){
+                    instances += entity['definition']['numberOfInstances']
+                    registeredDefinitions.push(entity['definition']['entityId'])
+                }
+            })
+            return `Instances (${instances})`
+        }else{
+            return `Instances (${this.lastSelectedEntity['definition']['numberOfInstances']})`
+        }
     }
   },
   methods:{
@@ -431,7 +446,8 @@ export default {
       let summary = ''
       Object.entries(groupedByWithKey).forEach((entry, index) => {
         const [className, entities] = entry
-        summary += `${className} (${entities.length})`
+          const entityType = className === 'Component' ? 'Instance' : className
+        summary += `${entityType}s (${entities.length})`
         if (index !== Object.entries(groupedByWithKey).length - 1){
           summary += ' - '
         }
@@ -572,6 +588,23 @@ export default {
 
 .active .entity {
   border: 2px solid green;
+}
+
+.v-card__title{
+    font-size: 1.02rem;
+}
+
+.v-card__subtitle{
+    font-size: 0.78rem;
+}
+
+.v-expansion-panel--active > .v-expansion-panel-header{
+    min-height: 32px;
+}
+
+.v-expansion-panel-header{
+    min-height: 32px;
+    padding: 12px 16px;
 }
 
 </style>


### PR DESCRIPTION
Nested mapped elements table is implemented with their buttons to improve UX when user want to play with mapped elements. Currently user can select mapped elements for both all category or selecting/deselecting sub elements under the related category. Then users can,
- Clear
- Isolate/Show All
- Hide
- Select
sketchup entities easily.