### PR TITLE
Fix (References): missing namespaces

### DIFF
--- a/speckle_connector/src/sketchup_model/dictionary/speckle_entity_dictionary_handler.rb
+++ b/speckle_connector/src/sketchup_model/dictionary/speckle_entity_dictionary_handler.rb
@@ -9,6 +9,8 @@ module SpeckleConnector
     module Dictionary
       # Dictionary handler of the speckle entity.
       class SpeckleEntityDictionaryHandler < DictionaryHandler
+        DICTIONARY_NAME = SPECKLE_BASE_OBJECT
+
         # Writes initial data while speckle entity is creating first time.
         # @param sketchup_entity [Sketchup::Entity] Sketchup entity to write data into it's attribute dictionary.
         # rubocop:disable Metrics/ParameterLists
@@ -26,6 +28,11 @@ module SpeckleConnector
           set_hash(sketchup_entity, initial_dict_data)
         end
         # rubocop:enable Metrics/ParameterLists
+
+        # @return [String] the name of the dictionary to read from
+        def self.dictionary_name
+          DICTIONARY_NAME
+        end
       end
     end
   end

--- a/speckle_connector/src/speckle_objects/revit/revit_definition.rb
+++ b/speckle_connector/src/speckle_objects/revit/revit_definition.rb
@@ -23,7 +23,7 @@ module SpeckleConnector
             definition_name = get_definition_name(definition)
             definition['name'] = definition_name
             definition['displayValue'] += definition['elements'] unless definition['elements'].nil?
-            BlockDefinition.to_native(state, definition, layer, entities, &convert_to_native)
+            SpeckleObjects::Other::BlockDefinition.to_native(state, definition, layer, entities, &convert_to_native)
           end
         end
       end

--- a/speckle_connector/src/speckle_objects/revit/revit_instance.rb
+++ b/speckle_connector/src/speckle_objects/revit/revit_instance.rb
@@ -30,8 +30,9 @@ module SpeckleConnector
             definition = state.sketchup_state.sketchup_model
                               .definitions[RevitDefinition.get_definition_name(block_definition)]
 
-            return BlockInstance.add_instance_from_definition(state, block, layer, entities,
-                                                              definition, false, &convert_to_native)
+            return SpeckleObjects::Other::BlockInstance.add_instance_from_definition(
+              state, block, layer, entities, definition, false, &convert_to_native
+            )
           end
         end
       end


### PR DESCRIPTION
Some files moved around when I implement mapper tool, so it effected to existing workflows, which is fixed.