### PR TITLE
Fix (Update): Update behavior for Revit > Sketchup

### DIFF
--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -5,6 +5,7 @@ module SpeckleConnector
 
   OBJECTS_BUILTELEMENTS_VIEW3D = 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
   OBJECTS_BUILTELEMENTS_REVIT_DIRECTSHAPE = 'Objects.BuiltElements.Revit.DirectShape'
+  OBJECTS_BUILTELEMENTS_REVIT_LEVEL = 'Objects.BuiltElements.Level:Objects.BuiltElements.Revit.RevitLevel'
 
   OBJECTS_GEOMETRY_LINE = 'Objects.Geometry.Line'
   OBJECTS_GEOMETRY_POLYLINE = 'Objects.Geometry.Polyline'

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -106,7 +106,18 @@ module SpeckleConnector
           definition_name = get_definition_name(definition_obj)
           application_id = definition_obj['applicationId']
           definition = sketchup_model.definitions[definition_name]
-          if definition && (definition.name == definition_name || definition.guid == application_id)
+
+          # It is important check for hosted elements that wrapped into component in sketchup.
+          # Their definition name might be stay same but their speckle ids should be checked
+          # to compare they updated or not.
+          children_changed = false
+          unless definition.nil?
+            previous_speckle_id = definition.get_attribute(SPECKLE_BASE_OBJECT, 'speckle_id')
+            children_changed = previous_speckle_id != definition_obj['id']
+          end
+
+          if definition && !children_changed &&
+             (definition.name == definition_name || definition.guid == application_id)
             return state, [definition]
           end
 

--- a/speckle_connector/src/speckle_objects/revit/revit_definition.rb
+++ b/speckle_connector/src/speckle_objects/revit/revit_definition.rb
@@ -16,7 +16,7 @@ module SpeckleConnector
             type = def_obj['type']
             category = def_obj['category']
 
-            return "#{family}-#{type}-#{category}-#{def_obj['id']}"
+            return "#{family}-#{type}-#{category}-#{def_obj['elementId']}"
           end
 
           def self.to_native(state, definition, entities, &convert_to_native)


### PR DESCRIPTION
There is a problem with hosted elements since we check only parent naming of definitions. I've added another check for `speckle_id`s to understand children has changed or not. Also some further improvements are done like level and section plane registration and clearing on update.

Closing #246