### PR TITLE
Fit (Instance): Disable aligning axes of displayValue components

### DIFF
--- a/speckle_connector/src/speckle_objects/other/display_value.rb
+++ b/speckle_connector/src/speckle_objects/other/display_value.rb
@@ -63,7 +63,7 @@ module SpeckleConnector
           instance = entities.add_instance(definition, transform)
           instance.name = obj['name'] unless obj['name'].nil?
           # Align instance axes that created from display value. (without any transform)
-          BlockInstance.align_instance_axes(instance)
+          # BlockInstance.align_instance_axes(instance)
           return state, [instance, definition]
         end
 


### PR DESCRIPTION
Aligning axes wasn't a good idea at all (for now). Let's do it as improvement at `2.15`