### PR TITLE
Fix (Mapper): inconsistency on mapped elements table state

### DIFF
--- a/speckle_connector/src/actions/hide_mappings_from_table.rb
+++ b/speckle_connector/src/actions/hide_mappings_from_table.rb
@@ -21,6 +21,11 @@ module SpeckleConnector
         flat_entities.each do |entity|
           next unless entity_ids.include?(entity.persistent_id)
 
+          if entity.is_a?(Sketchup::ComponentDefinition)
+            entity.instances.each do |instance|
+              instance.hidden = true
+            end
+          end
           entity.hidden = true
         end
 

--- a/speckle_connector/src/actions/select_mappings_from_table.rb
+++ b/speckle_connector/src/actions/select_mappings_from_table.rb
@@ -24,6 +24,9 @@ module SpeckleConnector
         flat_entities.each do |entity|
           next unless entity_ids.include?(entity.persistent_id)
 
+          if entity.is_a?(Sketchup::ComponentDefinition)
+            state.sketchup_state.sketchup_model.selection.add(entity.instances)
+          end
           state.sketchup_state.sketchup_model.selection.add(entity)
         end
 

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -100,23 +100,30 @@ module SpeckleConnector
           }
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def self.mapped_entity_details(entities)
           reverse_category_dictionary = Mapping::Category::RevitCategory.reverse_dictionary
           entities.collect do |entity|
             speckle_schema = get_schema(entity)
+            speckle_schema_definition = entity.respond_to?(:definition) ? get_schema(entity.definition) : nil
+            entity_type = entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split.first
             {
-              name: speckle_schema['name'],
-              category: speckle_schema['category'],
-              categoryName: reverse_category_dictionary[speckle_schema['category']],
-              method: speckle_schema['method'],
+              name: speckle_schema['name'] || speckle_schema_definition['name'],
+              category: speckle_schema['category'] || speckle_schema_definition['category'],
+              categoryName: reverse_category_dictionary[speckle_schema['category']] ||
+                reverse_category_dictionary[speckle_schema_definition['category']],
+              method: speckle_schema['method'] || speckle_schema_definition['method'],
               entityName: entity.respond_to?(:name) ? entity.name : '',
               entityId: entity.persistent_id,
-              entityType: entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split.first,
+              entityType: entity.is_a?(Sketchup::ComponentDefinition) ? 'Definition' : entity_type,
               schema: speckle_schema,
-              definitionSchema: entity.respond_to?(:definition) ? get_schema(entity.definition) : nil
+              definitionSchema: speckle_schema_definition
             }
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
       end
     end
   end

--- a/ui/src/components/MappedElements.vue
+++ b/ui/src/components/MappedElements.vue
@@ -165,6 +165,7 @@ export default {
     return {
       isIsolated: false,
       elementSelection: {},
+      categorySelection: [],
       mappedEntities: [],
       mappedEntityCount: 0,
       // Expanded indexes for mapped element table (Categories)
@@ -181,9 +182,9 @@ export default {
     }
   },
   computed: {
-    categorySelection() {
-        return Object.keys(this.elementSelection)
-    },
+    // categorySelection() {
+    //     return Object.keys(this.elementSelection)
+    // },
   },
   mounted() {
     sketchup.exec({name: "collect_mapped_entities", data: {}})
@@ -248,9 +249,14 @@ export default {
     selectMappedElementsOnSketchup(){
         sketchup.exec({ name: "select_mappings_from_table", data: this.elementSelection })
     },
+    // Update mapped elements table whenever mapped elements has changed.
     getMappedElementsTableData(){
       let groupByCategoryName = groupBy('categoryName')
       let groupedByCategoryName = groupByCategoryName(this.mappedEntities)
+      // Reset selected categories and elements whenever mapped elements states has changed
+      this.elementSelection = {}
+      this.categorySelection = []
+      this.mappedElementsExpandedIndexes = []
       this.mappedEntitiesTableData = Object.entries(groupedByCategoryName).map(
         (entry) => {
           const [categoryName, entities] = entry


### PR DESCRIPTION
Cached elements and category selection cleared whenever mapped objects are updated.
Also instances included to mapped element table reactions like, clear, isolate, hide, select.

Closing  #258 