### PR TITLE
Fix (Face): Merge coplanar doesn't work some cases

### DIFF
--- a/speckle_connector/src/sketchup_model/query/layer.rb
+++ b/speckle_connector/src/sketchup_model/query/layer.rb
@@ -33,6 +33,8 @@ module SpeckleConnector
 
           # @param string_layer_path [String] string layer path to split.
           def entity_layer_from_path(string_layer_path, separation = '::')
+            return string_layer_path if string_layer_path.nil?
+
             string_layer_path.split(separation).last
           end
         end


### PR DESCRIPTION
When layer property is missing on objects, callstack was jumping to rescue block, fixed.