### PR TITLE
Fix (Blocks): Eliminate nil block geometries

### DIFF
--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -75,7 +75,7 @@ module SpeckleConnector
           block_definition = BlockDefinition.new(
             units: units,
             name: definition.name,
-            geometry: geometry,
+            geometry: geometry.compact,
             always_face_camera: definition.behavior.always_face_camera?,
             sketchup_attributes: att,
             speckle_schema: speckle_schema,


### PR DESCRIPTION
This issue is reported on forum https://speckle.community/t/rhino-cant-receive-block-instance-from-sketchup/5777/4. Previously some object types produced nil value for block definition geometries. These objects won't send to speckle to prevent possible errors on receive on other connectors.