### PR TITLE
Fix (Mixpanel): Hash hostname of the serverUrl

### DIFF
--- a/ui/src/plugins/speckle-metrics.js
+++ b/ui/src/plugins/speckle-metrics.js
@@ -26,9 +26,11 @@ const SpeckleMetrics = {
           .digest('hex')
           .toUpperCase()
 
+      let serverUrl = new URL(localStorage.getItem('serverUrl'))
+
       let serverId = crypto
         .createHash('md5')
-        .update(localStorage.getItem('serverUrl').toLowerCase())
+        .update(serverUrl.hostname.toLowerCase())
         .digest('hex')
         .toUpperCase()
 


### PR DESCRIPTION
Pass hashed hostname of the server url instead of full URL.