### PR TITLE
Feat (Layers): support flat layers

### DIFF
--- a/speckle_connector/bootstrap.rb
+++ b/speckle_connector/bootstrap.rb
@@ -3,6 +3,7 @@
 require 'sketchup'
 require 'pathname'
 require 'speckle_connector/debug'
+require_relative 'src/log/log'
 require_relative 'src/ui/sketchup_ui'
 require_relative 'src/ui/ui_controller'
 require_relative 'src/commands/menu_command_handler'

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -77,6 +77,10 @@ module SpeckleConnector
         @from_revit ||= source_app.include?('revit')
       end
 
+      def from_rhino
+        @from_rhino ||= source_app.include?('rhino')
+      end
+
       def from_sketchup
         @from_sketchup ||= source_app.include?('sketchup')
       end
@@ -90,14 +94,9 @@ module SpeckleConnector
       # UI is responsible currently to fetch objects from ObjectLoader module by calling getAndConstruct method.
       # @param obj [Object] speckle commit object.
       def receive_commit_object(obj)
-        # First create layers on the sketchup before starting traversing
-        # @Named Views are exception here. It does not mean a layer. But it is anti-pattern for now.
-        # layers_relation = obj['layers_relation']
-
         unless from_revit
-          layers_relation = SpeckleObjects::Relations::Layers.extract_relations(obj)
           # Create layers and it's folders from layers relation on the model collection.
-          SpeckleObjects::Relations::Layers.to_native(layers_relation, sketchup_model) if layers_relation
+          SpeckleObjects::Relations::Layers.to_native(obj, source_app, sketchup_model)
         end
 
         # By default entities to fill is sketchup model's entities.

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -355,8 +355,6 @@ module SpeckleConnector
       # @param state [States::State] state of the application
       def convert_to_speckle_entities(state, speckle_objects_with_entities)
         return state if speckle_objects_with_entities.empty?
-
-
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/speckle_connector/src/log/log.rb
+++ b/speckle_connector/src/log/log.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SpeckleConnector
+  # Helper module for logging.
+  module Log
+    def self.write_to_file(text, file_name = 'log', path = "#{ENV['HOME']}/Desktop")
+      file_path = path + "/#{file_name}.json"
+      File.delete(file_path) if File.exist?(file_path)
+      File.write(file_path, text)
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/other/display_style.rb
+++ b/speckle_connector/src/speckle_objects/other/display_style.rb
@@ -9,7 +9,6 @@ module SpeckleConnector
     module Other
       # DisplayStyle object for layer.
       class DisplayStyle < Base
-
         def initialize(name:, color:, line_type:)
           super(
             speckle_type: OBJECTS_OTHER_DISPLAYSTYLE,

--- a/speckle_connector/src/speckle_objects/relations/layer.rb
+++ b/speckle_connector/src/speckle_objects/relations/layer.rb
@@ -44,12 +44,14 @@ module SpeckleConnector
           folder.add_layer(layer) if folder.is_a?(Sketchup::LayerFolder)
         end
 
+        # Flat layer conversion.
         def self.to_native_flat_layers(layers_relation, sketchup_model)
           speckle_layers = layers_relation[:elements]
 
           elements_to_layers(speckle_layers, sketchup_model)
         end
 
+        # Converts elements to layers with it's full path.
         def self.elements_to_layers(elements, sketchup_model)
           elements.each do |element|
             element[:name] = element[:full_path]
@@ -58,6 +60,7 @@ module SpeckleConnector
           end
         end
 
+        # Nested layer conversion with folders.
         def self.to_native_layer_folder(layers_relation, folder, sketchup_model)
           speckle_layers = layers_relation[:elements].select { |layer_or_fol| layer_or_fol[:elements].nil? }
 

--- a/speckle_connector/src/speckle_objects/relations/layer.rb
+++ b/speckle_connector/src/speckle_objects/relations/layer.rb
@@ -11,7 +11,7 @@ module SpeckleConnector
         SPECKLE_TYPE = 'Speckle.Core.Models.Collection'
 
         # rubocop:disable Metrics/ParameterLists
-        def initialize(name:, visible:, is_folder:, line_style: nil, color: nil, layers_and_folders: [],
+        def initialize(name:, visible:, is_folder:, full_path: nil, line_style: nil, color: nil, layers_and_folders: [],
                        application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
@@ -23,6 +23,7 @@ module SpeckleConnector
           self[:color] = color
           self[:visible] = visible
           self[:is_folder] =  is_folder
+          self[:full_path] =  full_path unless full_path.nil?
           self[:line_style] = line_style unless line_style.nil?
           self[:collectionType] = 'layer'
           self[:elements] = layers_and_folders if layers_and_folders.any?
@@ -43,14 +44,28 @@ module SpeckleConnector
           folder.add_layer(layer) if folder.is_a?(Sketchup::LayerFolder)
         end
 
-        def self.to_native_layer_folder(speckle_layer_folder, folder, sketchup_model)
-          speckle_layers = speckle_layer_folder[:elements].select { |layer_or_fol| layer_or_fol[:elements].nil? }
+        def self.to_native_flat_layers(layers_relation, sketchup_model)
+          speckle_layers = layers_relation[:elements]
+
+          elements_to_layers(speckle_layers, sketchup_model)
+        end
+
+        def self.elements_to_layers(elements, sketchup_model)
+          elements.each do |element|
+            element[:name] = element[:full_path]
+            to_native_layer(element, sketchup_model.layers, sketchup_model)
+            elements_to_layers(element[:elements], sketchup_model) unless element[:elements].nil?
+          end
+        end
+
+        def self.to_native_layer_folder(layers_relation, folder, sketchup_model)
+          speckle_layers = layers_relation[:elements].select { |layer_or_fol| layer_or_fol[:elements].nil? }
 
           speckle_layers.each do |speckle_layer|
             to_native_layer(speckle_layer, folder, sketchup_model)
           end
 
-          speckle_folders = speckle_layer_folder[:elements].reject { |layer_or_fol| layer_or_fol[:elements].nil? }
+          speckle_folders = layers_relation[:elements].reject { |layer_or_fol| layer_or_fol[:elements].nil? }
 
           speckle_folders.each do |speckle_folder|
             sub_folder = folder.add_folder(speckle_folder[:name])

--- a/speckle_connector/src/speckle_objects/speckle/core/models/layer_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/layer_collection.rb
@@ -99,6 +99,7 @@ module SpeckleConnector
               sketchup_model = state.sketchup_state.sketchup_model
               elements = layer_collection['elements']
               name = layer_collection['name']
+              name = layer_collection['full_path'] if layer_collection['full_path']
 
               layer = sketchup_model.layers.find { |l| l.display_name == name }
               layer_or_folder = layer if layer


### PR DESCRIPTION
There was an inconsistency between Rhino and SketchUp layers. Rhino layers are nested but sketchup layers are flat even if it seems like it has a tree structure with folders. Folders only make grouping of individual layers. That's why we cannot create layers that have same name even if they are in different folders, but in Rhino it is possible. So after this PR we will be able to receive Rhino layers as flat list in SketchUp as named full path. i.e. `1F::Walls::Interiors`.