### PR TITLE
Feat (Face): extrudable brep faces

### DIFF
--- a/speckle_connector/src/convertors/clean_up.rb
+++ b/speckle_connector/src/convertors/clean_up.rb
@@ -17,6 +17,8 @@ module SpeckleConnector
         faces.each { |face| face.edges.each { |edge| edges << edge } }
         edges.uniq!
         edges.each { |edge| remove_edge_have_coplanar_faces(edge, faces, false) }
+        # Remove remaining orphan edges
+        edges.reject(&:deleted?).select { |edge| edge.faces.empty? }.each(&:erase!)
         merged_faces(faces)
       end
 

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -242,7 +242,8 @@ module SpeckleConnector
       # rubocop:disable Metrics/PerceivedComplexity
       def traverse_commit_object(obj, layer, entities)
         if convertible_to_native?(obj)
-          @state = convert_to_native(@state, obj, layer, entities)
+          state, _ = convert_to_native(@state, obj, layer, entities)
+          @state = state
         elsif obj.is_a?(Hash) && obj.key?('speckle_type')
           return if ignored_speckle_type?(obj)
 
@@ -254,7 +255,8 @@ module SpeckleConnector
             end
           else
             # puts(">>> Found #{obj['speckle_type']}: #{obj['id']} with displayValue.")
-            @state = convert_to_native(@state, obj, layer, entities)
+            state, _ = convert_to_native(@state, obj, layer, entities)
+            @state = state
           end
         elsif obj.is_a?(Hash)
           obj.each_value { |value| traverse_commit_object(value, layer, entities) }
@@ -308,7 +310,7 @@ module SpeckleConnector
       rescue StandardError => e
         puts("Failed to convert #{obj['speckle_type']} (id: #{obj['id']})")
         puts(e)
-        return state
+        return state, []
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity

--- a/speckle_connector/src/speckle_entities/speckle_entity.rb
+++ b/speckle_connector/src/speckle_entities/speckle_entity.rb
@@ -124,7 +124,7 @@ module SpeckleConnector
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/CyclomaticComplexity
       def self.from_speckle_object(state, speckle_object, entities, stream_id)
-        return state if entities.empty?
+        return state, [] if entities.empty?
 
         speckle_id = speckle_object['id']
         application_id = speckle_object['applicationId']
@@ -140,7 +140,8 @@ module SpeckleConnector
           ent.write_initial_base_data
           speckle_state = speckle_state.with_speckle_entity(ent)
         end
-        state.with_speckle_state(speckle_state)
+        new_state = state.with_speckle_state(speckle_state)
+        return new_state, entities
       end
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/speckle_connector/src/speckle_objects/built_elements/network.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/network.rb
@@ -12,7 +12,7 @@ module SpeckleConnector
 
         def self.to_native(state, network, layer, entities, &convert_to_native)
           network['elements'].each do |element|
-            state = convert_to_native.call(state, element['elements'], layer, entities)
+            state, _converted_entities = convert_to_native.call(state, element['elements'], layer, entities)
           end
 
           return state, []

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -119,6 +119,10 @@ module SpeckleConnector
           added_faces = entities.grep(Sketchup::Face).last(native_mesh.polygons.length)
           mesh_layer_name = SketchupModel::Query::Layer.entity_layer_from_path(mesh['layer'])
           mesh_layer = state.sketchup_state.sketchup_model.layers.to_a.find { |l| l.display_name == mesh_layer_name }
+          # Merge only added faces in this scope
+          if model_preferences[:merge_coplanar_faces]
+            added_faces = Converters::CleanUp.merge_coplanar_faces(added_faces)
+          end
           added_faces.each do |face|
             face.layer = mesh_layer unless mesh_layer.nil?
             # Smooth edges if they already soft
@@ -129,10 +133,7 @@ module SpeckleConnector
                 .attribute_dictionaries_to_native(face, mesh['sketchup_attributes']['dictionaries'])
             end
           end
-          # Merge only added faces in this scope
-          if model_preferences[:merge_coplanar_faces]
-            added_faces = Converters::CleanUp.merge_coplanar_faces(added_faces)
-          end
+
           return state, added_faces
         end
         # rubocop:enable Metrics/MethodLength

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -122,13 +122,18 @@ module SpeckleConnector
           definition&.entities&.clear!
           definition ||= sketchup_model.definitions.add(definition_name)
 
+          faces_to_make_hard_edge = []
           if geometry.is_a?(Array)
             geometry.each do |obj|
-              state = convert_to_native.call(state, obj, layer, definition.entities)
+              state, added_entities = convert_to_native.call(state, obj, layer, definition.entities)
+              if added_entities.length == 1 && added_entities.first.is_a?(Sketchup::Face)
+                faces_to_make_hard_edge.append(added_entities.first)
+              end
             end
           end
+          faces_to_make_hard_edge.each { |f| f.edges.each { |e| e.soft = false } }
           if geometry.is_a?(Hash) && !definition_obj['speckle_type'].nil?
-            state = convert_to_native.call(state, geometry, layer, definition.entities)
+            state, _converted_entities = convert_to_native.call(state, geometry, layer, definition.entities)
           end
           # puts("definition finished: #{name} (#{application_id})")
           # puts("    entity count: #{definition.entities.count}")

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -122,16 +122,16 @@ module SpeckleConnector
           definition&.entities&.clear!
           definition ||= sketchup_model.definitions.add(definition_name)
 
-          faces_to_make_hard_edge = []
+          ngon_faces = []
           if geometry.is_a?(Array)
             geometry.each do |obj|
               state, added_entities = convert_to_native.call(state, obj, layer, definition.entities)
               if added_entities.length == 1 && added_entities.first.is_a?(Sketchup::Face)
-                faces_to_make_hard_edge.append(added_entities.first)
+                ngon_faces.append(added_entities.first)
               end
             end
           end
-          faces_to_make_hard_edge.each do |f|
+          ngon_faces.each do |f|
             f.edges.each do |e|
               e.soft = false
               e.smooth = false

--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -131,7 +131,12 @@ module SpeckleConnector
               end
             end
           end
-          faces_to_make_hard_edge.each { |f| f.edges.each { |e| e.soft = false } }
+          faces_to_make_hard_edge.each do |f|
+            f.edges.each do |e|
+              e.soft = false
+              e.smooth = false
+            end
+          end
           if geometry.is_a?(Hash) && !definition_obj['speckle_type'].nil?
             state, _converted_entities = convert_to_native.call(state, geometry, layer, definition.entities)
           end

--- a/speckle_connector/src/speckle_objects/speckle/core/models/layer_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/layer_collection.rb
@@ -105,7 +105,7 @@ module SpeckleConnector
               layer_or_folder = layer if layer
 
               elements.each do |element|
-                new_state = convert_to_native.call(state, element, layer_or_folder, entities)
+                new_state, _converted_entities = convert_to_native.call(state, element, layer_or_folder, entities)
                 state = new_state
               end
 

--- a/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
@@ -66,7 +66,7 @@ module SpeckleConnector
               elements = model_collection['elements']
 
               elements.each do |element|
-                new_state = convert_to_native.call(state, element, layer, entities)
+                new_state, _converted_entities = convert_to_native.call(state, element, layer, entities)
                 state = new_state
               end
 


### PR DESCRIPTION
Create ngons from meshes after cleanup. If the upcoming mesh turns to the single face then we call it as ngon and make it's face edges hard and non-smooth. By this way we create now extrudable faces that comes from Rhino.