### PR TITLE
Chore (DisplayValue): Better component names for displayValues

### DIFF
--- a/speckle_connector/src/speckle_objects/other/display_value.rb
+++ b/speckle_connector/src/speckle_objects/other/display_value.rb
@@ -42,6 +42,13 @@ module SpeckleConnector
           name
         end
 
+        # Get instance name as speckle_type if it is structured as `speckle_type::application_id`
+        def self.get_instance_name(definition_name)
+          return definition_name unless definition_name.include?('::')
+
+          definition_name.split('::').first
+        end
+
         # Creates a component definition and instance from a speckle object with a display value
         # @param state [States::State] state of the application.
         def self.to_native(state, obj, layer, entities, &convert_to_native)
@@ -50,11 +57,7 @@ module SpeckleConnector
           obj['name'] = get_definition_name(obj)
 
           state, _definitions = BlockDefinition.to_native(
-            state,
-            obj,
-            layer,
-            entities,
-            &convert_to_native
+            state, obj, layer, entities, &convert_to_native
           )
 
           definition = state.sketchup_state.sketchup_model.definitions[BlockDefinition.get_definition_name(obj)]
@@ -63,7 +66,7 @@ module SpeckleConnector
           t_arr = obj['transform']
           transform = t_arr.nil? ? Geom::Transformation.new : Other::Transform.to_native(t_arr, obj['units'])
           instance = entities.add_instance(definition, transform)
-          instance.name = obj['name'] unless obj['name'].nil?
+          instance.name = get_instance_name(obj['name']) unless obj['name'].nil?
           instance.layer = layer unless layer.nil?
           # Align instance axes that created from display value. (without any transform)
           # BlockInstance.align_instance_axes(instance)

--- a/speckle_connector/src/speckle_objects/other/display_value.rb
+++ b/speckle_connector/src/speckle_objects/other/display_value.rb
@@ -22,9 +22,10 @@ module SpeckleConnector
 
           return format_naming_convention([family, type, category, element_id]) unless element_id.nil?
 
-          return "def::#{def_obj['applicationId']}" unless def_obj['applicationId'].nil?
+          speckle_type = def_obj['speckle_type'].split('.').last
+          return "#{speckle_type}::#{def_obj['applicationId']}" unless def_obj['applicationId'].nil?
 
-          return "def::#{def_obj['id']}"
+          return "#{speckle_type}::#{def_obj['id']}"
         end
 
         def self.format_naming_convention(entries)


### PR DESCRIPTION
Previously we created definition and it's instance with the same name if definition and instance doesn't have any name defined. This is the case with displayValues. So when we try to receive displayValues as instance, we formatted it's name as `def::application_id` before for both definition and instance. Now we changed it as `speckle_type::application_id` for definition name and for it's instance just `speckle_type`.

![image](https://github.com/specklesystems/speckle-sketchup/assets/45078678/08c06be3-e9c1-48c1-bee9-72e6efda1280)
