### PR TITLE
Fix (DisplayValue): Use name of display value first

### DIFF
--- a/speckle_connector/src/speckle_objects/other/display_value.rb
+++ b/speckle_connector/src/speckle_objects/other/display_value.rb
@@ -22,6 +22,11 @@ module SpeckleConnector
 
           return format_naming_convention([family, type, category, element_id]) unless element_id.nil?
 
+          name = def_obj['name']
+          return "#{name}::#{def_obj['applicationId']}" if !name.nil? && !def_obj['applicationId'].nil?
+
+          return "#{name}::#{def_obj['id']}" unless name.nil?
+
           speckle_type = def_obj['speckle_type'].split('.').last
           return "#{speckle_type}::#{def_obj['applicationId']}" unless def_obj['applicationId'].nil?
 


### PR DESCRIPTION
For component definition and instance use first name of the display value if exists.