### PR TITLE
Feat (Edge): support rhino curve types

### DIFF
--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -12,6 +12,7 @@ module SpeckleConnector
 
   OBJECTS_GEOMETRY_LINE = 'Objects.Geometry.Line'
   OBJECTS_GEOMETRY_POLYLINE = 'Objects.Geometry.Polyline'
+  OBJECTS_GEOMETRY_POLYCURVE = 'Objects.Geometry.Polycurve'
   OBJECTS_GEOMETRY_MESH = 'Objects.Geometry.Mesh'
   OBJECTS_GEOMETRY_BREP = 'Objects.Geometry.Brep'
 

--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -13,6 +13,8 @@ module SpeckleConnector
   OBJECTS_GEOMETRY_LINE = 'Objects.Geometry.Line'
   OBJECTS_GEOMETRY_POLYLINE = 'Objects.Geometry.Polyline'
   OBJECTS_GEOMETRY_POLYCURVE = 'Objects.Geometry.Polycurve'
+  OBJECTS_GEOMETRY_ARC = 'Objects.Geometry.Arc'
+  OBJECTS_GEOMETRY_CIRCLE = 'Objects.Geometry.Circle'
   OBJECTS_GEOMETRY_MESH = 'Objects.Geometry.Mesh'
   OBJECTS_GEOMETRY_BREP = 'Objects.Geometry.Brep'
 

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -12,6 +12,7 @@ require_relative '../speckle_objects/other/display_value'
 require_relative '../speckle_objects/revit/revit_instance'
 require_relative '../speckle_objects/geometry/point'
 require_relative '../speckle_objects/geometry/line'
+require_relative '../speckle_objects/geometry/polycurve'
 require_relative '../speckle_objects/geometry/mesh'
 require_relative '../speckle_objects/built_elements/view3d'
 require_relative '../speckle_objects/built_elements/network'
@@ -46,6 +47,7 @@ module SpeckleConnector
       # Class aliases
       POINT = GEOMETRY::Point
       LINE = GEOMETRY::Line
+      POLYCURVE = GEOMETRY::Polycurve
       MESH = GEOMETRY::Mesh
       BLOCK_DEFINITION = OTHER::BlockDefinition
       BLOCK_INSTANCE = OTHER::BlockInstance
@@ -274,6 +276,7 @@ module SpeckleConnector
       SPECKLE_OBJECT_TO_NATIVE = {
         OBJECTS_GEOMETRY_LINE => LINE.method(:to_native),
         OBJECTS_GEOMETRY_POLYLINE => LINE.method(:to_native),
+        OBJECTS_GEOMETRY_POLYCURVE => POLYCURVE.method(:to_native),
         OBJECTS_GEOMETRY_MESH => MESH.method(:to_native),
         OBJECTS_GEOMETRY_BREP => MESH.method(:to_native),
         OBJECTS_OTHER_BLOCKDEFINITION => BLOCK_DEFINITION.method(:to_native),

--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -13,6 +13,8 @@ require_relative '../speckle_objects/revit/revit_instance'
 require_relative '../speckle_objects/geometry/point'
 require_relative '../speckle_objects/geometry/line'
 require_relative '../speckle_objects/geometry/polycurve'
+require_relative '../speckle_objects/geometry/arc'
+require_relative '../speckle_objects/geometry/circle'
 require_relative '../speckle_objects/geometry/mesh'
 require_relative '../speckle_objects/built_elements/view3d'
 require_relative '../speckle_objects/built_elements/network'
@@ -48,6 +50,8 @@ module SpeckleConnector
       POINT = GEOMETRY::Point
       LINE = GEOMETRY::Line
       POLYCURVE = GEOMETRY::Polycurve
+      ARC = GEOMETRY::Arc
+      CIRCLE = GEOMETRY::Circle
       MESH = GEOMETRY::Mesh
       BLOCK_DEFINITION = OTHER::BlockDefinition
       BLOCK_INSTANCE = OTHER::BlockInstance
@@ -62,6 +66,9 @@ module SpeckleConnector
       CONVERTABLE_SPECKLE_TYPES = %w[
         Objects.Geometry.Line
         Objects.Geometry.Polyline
+        Objects.Geometry.Polycurve
+        Objects.Geometry.Arc
+        Objects.Geometry.Circle
         Objects.Geometry.Mesh
         Objects.Geometry.Brep
         Objects.Other.BlockInstance
@@ -277,6 +284,8 @@ module SpeckleConnector
         OBJECTS_GEOMETRY_LINE => LINE.method(:to_native),
         OBJECTS_GEOMETRY_POLYLINE => LINE.method(:to_native),
         OBJECTS_GEOMETRY_POLYCURVE => POLYCURVE.method(:to_native),
+        OBJECTS_GEOMETRY_ARC => ARC.method(:to_native),
+        OBJECTS_GEOMETRY_CIRCLE => CIRCLE.method(:to_native),
         OBJECTS_GEOMETRY_MESH => MESH.method(:to_native),
         OBJECTS_GEOMETRY_BREP => MESH.method(:to_native),
         OBJECTS_OTHER_BLOCKDEFINITION => BLOCK_DEFINITION.method(:to_native),

--- a/speckle_connector/src/speckle_objects/geometry/arc.rb
+++ b/speckle_connector/src/speckle_objects/geometry/arc.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../../constants/type_constants'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module Geometry
+      # Arc object definition for Speckle.
+      class Arc < Base
+        SPECKLE_TYPE = OBJECTS_GEOMETRY_ARC
+
+        # @param [States::State] state of the current application.
+        # @param arc [Object] object represents Speckle Arc.
+        # @param layer [Sketchup::Layer] layer to add {Sketchup::Edge} into it.
+        # @param entities [Sketchup::Entities] entities collection to add {Sketchup::Edge} into it.
+        def self.to_native(state, arc, layer, entities, &_convert_to_native)
+          plane = arc['plane']
+          units = arc['units']
+          origin = Point.to_native(plane['origin']['x'], plane['origin']['y'], plane['origin']['z'], units)
+          normal = Vector.to_native(plane['normal']['x'], plane['normal']['y'], plane['normal']['z'], units)
+          x_axis = Vector.to_native(plane['xdir']['x'], plane['xdir']['y'], plane['xdir']['z'], units)
+          radius = Geometry.length_to_native(arc['radius'], units)
+          edges = entities.add_arc(origin, x_axis, normal, radius, arc['startAngle'], arc['endAngle'])
+          edges.each { |edge| edge.layer = layer }
+          return state, edges
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/geometry/circle.rb
+++ b/speckle_connector/src/speckle_objects/geometry/circle.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'point'
+require_relative 'vector'
+require_relative 'length'
+require_relative '../base'
+require_relative '../../constants/type_constants'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module Geometry
+      # Circle object definition for Speckle.
+      class Circle < Base
+        SPECKLE_TYPE = OBJECTS_GEOMETRY_CIRCLE
+
+        # @param [States::State] state of the current application.
+        # @param circle [Object] object represents Speckle Circle.
+        # @param layer [Sketchup::Layer] layer to add {Sketchup::Edge} into it.
+        # @param entities [Sketchup::Entities] entities collection to add {Sketchup::Edge} into it.
+        def self.to_native(state, circle, layer, entities, &_convert_to_native)
+          plane = circle['plane']
+          units = circle['units']
+          origin = Point.to_native(plane['origin']['x'], plane['origin']['y'], plane['origin']['z'], units)
+          normal = Vector.to_native(plane['normal']['x'], plane['normal']['y'], plane['normal']['z'], units)
+          radius = Geometry.length_to_native(circle['radius'], units)
+          edges = entities.add_circle(origin, normal, radius)
+          edges.each { |edge| edge.layer = layer }
+          return state, edges
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/geometry/line.rb
+++ b/speckle_connector/src/speckle_objects/geometry/line.rb
@@ -60,7 +60,7 @@ module SpeckleConnector
           )
         end
 
-        # @param _state [States::State] state of the application.
+        # @param state [States::State] state of the application.
         # @param line [Object] object represents Speckle line.
         # @param layer [Sketchup::Layer] layer to add {Sketchup::Edge} into it.
         # @param entities [Sketchup::Entities] entities collection to add {Sketchup::Edge} into it.

--- a/speckle_connector/src/speckle_objects/geometry/polycurve.rb
+++ b/speckle_connector/src/speckle_objects/geometry/polycurve.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../../constants/type_constants'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module Geometry
+      # Polycurve object definition for Speckle.
+      # It basically groups the lines-curves under it's `segments` property.
+      class Polycurve < Base
+        SPECKLE_TYPE = OBJECTS_GEOMETRY_POLYCURVE
+
+        def self.to_native(state, polycurve, layer, entities, &convert_to_native)
+          polycurve['displayValue'] = polycurve['segments']
+          convert_to_native.call(state, polycurve, layer, entities)
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/geometry/vector.rb
+++ b/speckle_connector/src/speckle_objects/geometry/vector.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'length'
 require_relative '../base'
 
 module SpeckleConnector
@@ -24,6 +25,14 @@ module SpeckleConnector
           self[:y] = y
           self[:z] = z
           self[:units] = units
+        end
+
+        def self.to_native(x, y, z, units)
+          Geom::Vector3d.new(
+            Geometry.length_to_native(x, units),
+            Geometry.length_to_native(y, units),
+            Geometry.length_to_native(z, units)
+          )
         end
       end
     end


### PR DESCRIPTION
Rhino has several curve types when we compare with SketchUp. SketchUp basically supports edges and arcs only. But in Rhino we have Line, Curve, PolyCurve, NurbsCurve, Arc, Ellipse maybe more. Currently we support all except ellipses. Ellipses doesn't supported by SketchUp. We can do workaround by creating circle with small radius and scaling by other axis with factor but it doesn't worth for now.