### PR TITLE
Fix (Send): Do not send hidden geometries in components

### DIFF
--- a/speckle_connector/src/speckle_objects/other/block_definition.rb
+++ b/speckle_connector/src/speckle_objects/other/block_definition.rb
@@ -149,6 +149,7 @@ module SpeckleConnector
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         def self.group_entities_to_speckle(entities, preferences, speckle_state, parent, &convert)
+          entities = entities.reject(&:hidden?)
           orphan_edges = entities.grep(Sketchup::Edge).filter { |edge| edge.faces.none? }
           lines = orphan_edges.collect do |orphan_edge|
             new_speckle_state, converted = convert.call(orphan_edge, preferences, speckle_state, parent)

--- a/speckle_connector/src/speckle_objects/other/display_style.rb
+++ b/speckle_connector/src/speckle_objects/other/display_style.rb
@@ -9,7 +9,6 @@ module SpeckleConnector
     module Other
       # DisplayStyle object for layer.
       class DisplayStyle < Base
-
         def initialize(name:, color:, line_type:)
           super(
             speckle_type: OBJECTS_OTHER_DISPLAYSTYLE,


### PR DESCRIPTION
Issue with send for hidden geometries in the components. Now we do not send them!