### PR TITLE
Feat (Mapper): mapping for default floor

### DIFF
--- a/speckle_connector/src/actions/events/selection_event_action.rb
+++ b/speckle_connector/src/actions/events/selection_event_action.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require_relative 'event_action'
-require_relative '../../mapping/category/revit_category'
+require_relative '../../mapper/category/revit_category'
 require_relative '../../sketchup_model/reader/speckle_entities_reader'
 require_relative '../../sketchup_model/query/entity'
 
 module SpeckleConnector
   module Actions
     module Events
-      # Update selected speckle objects when the selection changes for mapping tool.
+      # Update selected speckle objects when the selection changes for mapper tool.
       class SelectionEventAction < EventAction
         # @param state [States::State] the current state of Speckle application.
         # @return [States::State] the new updated state object
@@ -21,7 +21,7 @@ module SpeckleConnector
             mappingMethods: [
               'Direct Shape'
             ],
-            categories: Mapping::Category::RevitCategory.to_a
+            categories: Mapper::Category::RevitCategory.to_a
           }
           selection = { selection: [], mappingMethods: [], categories: [] } if sketchup_selection.none?
 

--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -7,6 +7,7 @@ module SpeckleConnector
 
   OBJECTS_BUILTELEMENTS_VIEW3D = 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
   OBJECTS_BUILTELEMENTS_NETWORK = 'Objects.BuiltElements.Network'
+  OBJECTS_BUILTELEMENTS_FLOOR = 'Objects.BuiltElements.Floor'
   OBJECTS_BUILTELEMENTS_REVIT_DIRECTSHAPE = 'Objects.BuiltElements.Revit.DirectShape'
   OBJECTS_BUILTELEMENTS_REVIT_LEVEL = 'Objects.BuiltElements.Level:Objects.BuiltElements.Revit.RevitLevel'
 

--- a/speckle_connector/src/mapper/category/revit_category.rb
+++ b/speckle_connector/src/mapper/category/revit_category.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SpeckleConnector
-  module Mapping
+  module Mapper
     module Category
       # Revit categories.
       class RevitCategory < Hash

--- a/speckle_connector/src/mapper/mapper.rb
+++ b/speckle_connector/src/mapper/mapper.rb
@@ -28,12 +28,12 @@ module SpeckleConnector
       mapped_selection
     end
 
-    def self.to_speckle(entity, units)
+    def self.to_speckle(entity, units, global_transformation: nil)
       speckle_schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(entity)
       return speckle_schema if speckle_schema.nil?
 
-      if speckle_schema["method"] == 'Default Floor'
-        return SpeckleObjects::BuiltElements::Floor.to_speckle_schema(entity, units)
+      if speckle_schema['method'] == 'Default Floor'
+        return SpeckleObjects::BuiltElements::Floor.to_speckle_schema(entity, units, global_transformation: global_transformation)
       end
 
       return speckle_schema

--- a/speckle_connector/src/mapper/mapper.rb
+++ b/speckle_connector/src/mapper/mapper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../speckle_objects/built_elements/floor'
+require_relative '../sketchup_model/query/entity'
+require_relative '../sketchup_model/reader/speckle_entities_reader'
+require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  # Mapper is a tool to convert SketchUp entities to other applications' native objects.
+  module Mapper
+    # Collects mapped entities on selection as flat list.
+    def self.mapped_entities_on_selection(sketchup_model)
+      flat_selection_with_path = SketchupModel::Query::Entity.flat_entities_with_path(
+        sketchup_model.selection,
+        [Sketchup::Face, Sketchup::ComponentInstance, Sketchup::Group], [sketchup_model]
+      )
+      mapped_selection = []
+      flat_selection_with_path.each do |entities|
+        entity = entities[0]
+        is_entity_mapped = SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entity)
+        if entity.respond_to?(:definition)
+          is_definition_mapped = SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entity.definition)
+          mapped_selection.append(entities) if is_entity_mapped || is_definition_mapped
+          next
+        end
+        mapped_selection.append(entities) if is_entity_mapped
+      end
+      mapped_selection
+    end
+
+    def self.to_speckle(entity, units)
+      speckle_schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(entity)
+      return speckle_schema if speckle_schema.nil?
+
+      if speckle_schema["method"] == 'Default Floor'
+        return SpeckleObjects::BuiltElements::Floor.to_speckle_schema(entity, units)
+      end
+
+      return speckle_schema
+    end
+  end
+end

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -2,7 +2,7 @@
 
 require_relative '../dictionary/speckle_schema_dictionary_handler'
 require_relative '../../speckle_entities/speckle_entity'
-require_relative '../../mapping/category/revit_category'
+require_relative '../../mapper/category/revit_category'
 require_relative '../../constants/dict_constants'
 
 module SpeckleConnector
@@ -103,7 +103,7 @@ module SpeckleConnector
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         def self.mapped_entity_details(entities)
-          reverse_category_dictionary = Mapping::Category::RevitCategory.reverse_dictionary
+          reverse_category_dictionary = Mapper::Category::RevitCategory.reverse_dictionary
           entities.collect do |entity|
             speckle_schema = get_schema(entity)
             speckle_schema_definition = entity.respond_to?(:definition) ? get_schema(entity.definition) : nil

--- a/speckle_connector/src/speckle_objects/built_elements/floor.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/floor.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../other/render_material'
+require_relative '../geometry/line'
+require_relative '../geometry/polyline'
+require_relative '../../constants/type_constants'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module BuiltElements
+      # Floor object.
+      class Floor < Base
+        SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_FLOOR
+
+        def initialize(outline:, voids:, units:, material:, application_id: nil)
+          super(
+            speckle_type: SPECKLE_TYPE,
+            total_children_count: 0,
+            application_id: application_id,
+            id: nil
+          )
+          self[:outline] = outline
+          self[:voids] = voids
+          self[:units] = units
+          self[:renderMaterial] = material
+        end
+
+        # @param face [Sketchup::Face] face to get speckle schema for floor.
+        def self.to_speckle_schema(face, units)
+          outline = Geometry::Polyline.from_loop(face.loops.first, units)
+          voids = []
+          if face.loops.length > 1
+            voids = face.loops[1..face.loops.length - 1].collect do |loop|
+              Geometry::Polyline.from_loop(loop, units)
+            end
+          end
+          Floor.new(
+            outline: outline,
+            voids: voids,
+            units: units,
+            material: Other::RenderMaterial.from_material(face.material || face.back_material),
+            application_id: face.entityID
+          )
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/built_elements/floor.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/floor.rb
@@ -35,11 +35,12 @@ module SpeckleConnector
               Geometry::Polyline.from_loop(loop, units, global_transformation: global_transformation)
             end
           end
+          material = face.material || face.back_material
           Floor.new(
             outline: outline,
             voids: voids,
             units: units,
-            material: Other::RenderMaterial.from_material(face.material || face.back_material),
+            material: material.nil? ? nil : Other::RenderMaterial.from_material(face.material || face.back_material),
             application_id: face.entityID
           )
         end

--- a/speckle_connector/src/speckle_objects/built_elements/floor.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/floor.rb
@@ -27,12 +27,12 @@ module SpeckleConnector
         end
 
         # @param face [Sketchup::Face] face to get speckle schema for floor.
-        def self.to_speckle_schema(face, units)
-          outline = Geometry::Polyline.from_loop(face.loops.first, units)
+        def self.to_speckle_schema(face, units, global_transformation: nil)
+          outline = Geometry::Polyline.from_loop(face.loops.first, units, global_transformation: global_transformation)
           voids = []
           if face.loops.length > 1
             voids = face.loops[1..face.loops.length - 1].collect do |loop|
-              Geometry::Polyline.from_loop(loop, units)
+              Geometry::Polyline.from_loop(loop, units, global_transformation: global_transformation)
             end
           end
           Floor.new(

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -154,7 +154,7 @@ module SpeckleConnector
           has_any_soften_edge = face.edges.any?(&:soft?)
           att = dictionaries.any? ? { is_soften: has_any_soften_edge, dictionaries: dictionaries }
                   : { is_soften: has_any_soften_edge }
-          speckle_schema = Mapper.to_speckle(face, units)
+          speckle_schema = Mapper.to_speckle(face, units, global_transformation: global_transform)
           material = face.material || face.back_material || parent_material
           speckle_mesh = Mesh.new(
             units: units,

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -3,6 +3,7 @@
 require_relative '../base'
 require_relative '../geometry/bounding_box'
 require_relative '../other/render_material'
+require_relative '../../mapper/mapper'
 require_relative '../../sketchup_model/query/entity'
 require_relative '../../convertors/clean_up'
 require_relative '../../sketchup_model/dictionary/base_dictionary_handler'
@@ -51,7 +52,7 @@ module SpeckleConnector
           self[:'@(31250)vertices'] = vertices
           self[:'@(62500)faces'] = faces
           self[:sketchup_attributes] = sketchup_attributes if sketchup_attributes.any?
-          self[:SpeckleSchema] = speckle_schema if speckle_schema.any?
+          self['@SpeckleSchema'] = speckle_schema if speckle_schema.any?
         end
         # rubocop:enable Metrics/ParameterLists
 
@@ -153,7 +154,7 @@ module SpeckleConnector
           has_any_soften_edge = face.edges.any?(&:soft?)
           att = dictionaries.any? ? { is_soften: has_any_soften_edge, dictionaries: dictionaries }
                   : { is_soften: has_any_soften_edge }
-          speckle_schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(face)
+          speckle_schema = Mapper.to_speckle(face, units)
           material = face.material || face.back_material || parent_material
           speckle_mesh = Mesh.new(
             units: units,

--- a/speckle_connector/src/speckle_objects/geometry/polyline.rb
+++ b/speckle_connector/src/speckle_objects/geometry/polyline.rb
@@ -5,16 +5,21 @@ require_relative 'point'
 require_relative 'bounding_box'
 require_relative '../base'
 require_relative '../primitive/interval'
-require_relative '../../sketchup_model/dictionary/base_dictionary_handler'
-require_relative '../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
 
 module SpeckleConnector
   module SpeckleObjects
     module Geometry
-      # Line object definition for Speckle.
+      # Polyline object definition for Speckle.
       class Polyline < Base
         SPECKLE_TYPE = OBJECTS_GEOMETRY_POLYLINE
 
+        # @param value [Array<Numeric>] polygon vertex coordinates as flat list.
+        # @param domain [Primitive::Interval] domain of the polyline.
+        # @param length [Numeric] length of the polyline.
+        # @param closed [Boolean] whether polyline is closed or not.
+        # @param units [String] units of the polyline.
+        # @param application_id [String] application id of the polyline which corresponds to persistent_id of the Loop.
+        # rubocop:disable Metrics/ParameterLists
         def initialize(value:, domain:, length:, closed:, units:, application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
@@ -28,6 +33,7 @@ module SpeckleConnector
           self[:closed] = closed
           self[:units] = units
         end
+        # rubocop:enable Metrics/ParameterLists
 
         # @param loop [Sketchup::Loop] loop to convert closed speckle polyline.
         def self.from_loop(loop, units)
@@ -46,7 +52,7 @@ module SpeckleConnector
             length: length,
             units: units,
             closed: true,
-            application_id: loop.entityID
+            application_id: loop.persistent_id.to_s
           )
         end
       end

--- a/speckle_connector/src/speckle_objects/geometry/polyline.rb
+++ b/speckle_connector/src/speckle_objects/geometry/polyline.rb
@@ -36,8 +36,12 @@ module SpeckleConnector
         # rubocop:enable Metrics/ParameterLists
 
         # @param loop [Sketchup::Loop] loop to convert closed speckle polyline.
-        def self.from_loop(loop, units)
-          points = loop.vertices.collect(&:position)
+        def self.from_loop(loop, units, global_transformation: nil)
+          points = loop.vertices.collect do |vertex|
+            position = vertex.position
+            position = vertex.position.transform!(global_transformation) unless global_transformation.nil?
+            position
+          end
           values = points.collect do |p|
             [Geometry.length_to_speckle(p.x, units),
              Geometry.length_to_speckle(p.y, units),

--- a/speckle_connector/src/speckle_objects/geometry/polyline.rb
+++ b/speckle_connector/src/speckle_objects/geometry/polyline.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative 'length'
+require_relative 'point'
+require_relative 'bounding_box'
+require_relative '../base'
+require_relative '../primitive/interval'
+require_relative '../../sketchup_model/dictionary/base_dictionary_handler'
+require_relative '../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module Geometry
+      # Line object definition for Speckle.
+      class Polyline < Base
+        SPECKLE_TYPE = OBJECTS_GEOMETRY_POLYLINE
+
+        def initialize(value:, domain:, length:, closed:, units:, application_id: nil)
+          super(
+            speckle_type: SPECKLE_TYPE,
+            total_children_count: 0,
+            application_id: application_id,
+            id: nil
+          )
+          self[:value] = value
+          self[:domain] = domain
+          self[:length] = length
+          self[:closed] = closed
+          self[:units] = units
+        end
+
+        # @param loop [Sketchup::Loop] loop to convert closed speckle polyline.
+        def self.from_loop(loop, units)
+          points = loop.vertices.collect(&:position)
+          values = points.collect do |p|
+            [Geometry.length_to_speckle(p.x, units),
+             Geometry.length_to_speckle(p.y, units),
+             Geometry.length_to_speckle(p.z, units)]
+          end.flatten
+          loop_length = loop.edges.sum(&:length)
+          length = Geometry.length_to_speckle(loop_length, units)
+          domain = Primitive::Interval.from_lengths(0, loop_length, units)
+          Polyline.new(
+            value: values,
+            domain: domain,
+            length: length,
+            units: units,
+            closed: true,
+            application_id: loop.entityID
+          )
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
@@ -4,6 +4,7 @@ require_relative 'collection'
 require_relative 'layer_collection'
 require_relative '../../../built_elements/view3d'
 require_relative '../../../built_elements/revit/direct_shape'
+require_relative '../../../../mapper/mapper'
 
 module SpeckleConnector
   module SpeckleObjects
@@ -31,7 +32,7 @@ module SpeckleConnector
               )
 
               # Direct shapes will pass directly to elements which are already flattened with all children
-              model_collection[:elements] += collect_direct_shapes(sketchup_model, units, preferences)
+              model_collection[:elements] += collect_mapped_entities(sketchup_model, units, preferences)
 
               # Views will pass directly to elements since they don't have any relation with layers and geometries.
               model_collection[:elements] += VIEW3D.from_model(sketchup_model, units) if sketchup_model.pages.any?
@@ -52,8 +53,9 @@ module SpeckleConnector
               return speckle_state, model_collection
             end
 
-            def self.collect_direct_shapes(sketchup_model, units, preferences)
-              DIRECT_SHAPE.direct_shapes_on_selection(sketchup_model).collect do |entities|
+            # @param sketchup_model [Sketchup::Model] active model to retrieve and convert mapped entities.
+            def self.collect_mapped_entities(sketchup_model, units, preferences)
+              Mapper.mapped_entities_on_selection(sketchup_model).collect do |entities|
                 entity = entities[0]
                 path = entities[1..-1]
 

--- a/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
@@ -14,7 +14,9 @@ module SpeckleConnector
           # ModelCollection object that collect other speckle objects under it's elements.
           class ModelCollection < Collection
             DIRECT_SHAPE = SpeckleObjects::BuiltElements::Revit::DirectShape
+            QUERY = SketchupModel::Query
             VIEW3D = SpeckleObjects::BuiltElements::View3d
+            SPECKLE_SCHEMA_DICTIONARY_HANDLER = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler
             def initialize(name:, active_layer:, elements: [], application_id: nil)
               super(
                 name: name,
@@ -32,7 +34,7 @@ module SpeckleConnector
               )
 
               # Direct shapes will pass directly to elements which are already flattened with all children
-              model_collection[:elements] += collect_mapped_entities(sketchup_model, units, preferences)
+              model_collection[:elements] += collect_mapped_entities(sketchup_model, units, preferences, &convert)
 
               # Views will pass directly to elements since they don't have any relation with layers and geometries.
               model_collection[:elements] += VIEW3D.from_model(sketchup_model, units) if sketchup_model.pages.any?
@@ -54,13 +56,10 @@ module SpeckleConnector
             end
 
             # @param sketchup_model [Sketchup::Model] active model to retrieve and convert mapped entities.
-            def self.collect_mapped_entities(sketchup_model, units, preferences)
-              Mapper.mapped_entities_on_selection(sketchup_model).collect do |entities|
-                entity = entities[0]
-                path = entities[1..-1]
-
-                direct_shape = DIRECT_SHAPE.from_entity(entity, path, units, preferences)
-                [direct_shape, [entity]]
+            def self.collect_mapped_entities(sketchup_model, units, preferences, &convert)
+              mapped_entities = Mapper.mapped_entities_on_selection(sketchup_model)
+              mapped_entities.collect do |entity_with_path|
+                convert_mapped_entity(entity_with_path, preferences, units)
               end
             end
 
@@ -76,6 +75,24 @@ module SpeckleConnector
               state.sketchup_state.sketchup_model.active_layer = active_layer unless active_layer.nil?
 
               return state, []
+            end
+
+            def self.convert_mapped_entity(entity_with_path, preferences, units)
+              entity = entity_with_path[0]
+              path = entity_with_path[1..-1]
+
+              method = SPECKLE_SCHEMA_DICTIONARY_HANDLER.get_attribute(entity, 'method')
+
+              if method.include?('Floor') && entity.is_a?(Sketchup::Face)
+                global_transformation = QUERY::Entity.global_transformation(entity, path)
+                floor = SpeckleObjects::Geometry::Mesh.from_face(face: entity, units: units,
+                                                                 model_preferences: preferences,
+                                                                 global_transform: global_transformation)
+                return [floor, [entity]]
+              end
+
+              direct_shape = DIRECT_SHAPE.from_entity(entity, path, units, preferences)
+              return [direct_shape, [entity]]
             end
           end
         end


### PR DESCRIPTION
Attach SpeckleSchema to Face as `Object.BuiltElements.Floor` when it is mapped as `Default Floor`. Mapped elements converted with it's global coordinates if they are in any Group or Component.