### PR TITLE
Feat (Mapper): mapper method by selection and floor creation

### DIFF
--- a/speckle_connector/src/actions/apply_mappings.rb
+++ b/speckle_connector/src/actions/apply_mappings.rb
@@ -9,12 +9,16 @@ module SpeckleConnector
   module Actions
     # Apply mappings for selected entities.
     class ApplyMappings < Action
-      def initialize(entities_to_map, method, category, name, is_definition)
+      def initialize(entities_to_map, method, category, family,
+                     family_type, level, name, is_definition)
         super()
         @entities_to_map = entities_to_map
         @method = method
         @category = category
         @name = name
+        @family = family
+        @family_type = family_type
+        @level = level
         @is_definition = is_definition
       end
 
@@ -51,6 +55,9 @@ module SpeckleConnector
           SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :category, @category)
           SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :name, name)
           SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :method, @method)
+          SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :family, @family)
+          SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :family_type, @family_type)
+          SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.set_attribute(entity, :level, @level)
           speckle_state = speckle_state.with_mapped_entity(entity)
         end
 

--- a/speckle_connector/src/actions/clear_mapper_source.rb
+++ b/speckle_connector/src/actions/clear_mapper_source.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+require_relative '../sketchup_model/dictionary/speckle_entity_dictionary_handler'
+
+module SpeckleConnector
+  module Actions
+    # Clear mapper source.
+    class ClearMapperSource < Action
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def self.update_state(state, _data)
+        new_speckle_state = state.speckle_state.with_removed_mapper_source
+        erase_levels(state)
+        state.with_speckle_state(new_speckle_state)
+      end
+
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      def self.erase_levels(state)
+        levels = state.sketchup_state.sketchup_model.definitions.select do |definition|
+          SketchupModel::Dictionary::SpeckleEntityDictionaryHandler.get_attribute(definition, :speckle_type) ==
+            OBJECTS_BUILTELEMENTS_REVIT_LEVEL
+        end
+        levels.each do |level|
+          level.entities.clear!
+          level.instances.each(&:erase!)
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/events/selection_event_action.rb
+++ b/speckle_connector/src/actions/events/selection_event_action.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'event_action'
+require_relative '../mapper_selection_changed'
 require_relative '../../mapper/category/revit_category'
 require_relative '../../sketchup_model/reader/speckle_entities_reader'
 require_relative '../../sketchup_model/reader/mapper_reader'
@@ -19,65 +20,9 @@ module SpeckleConnector
           # Get sketchup selection
           sketchup_selection = state.sketchup_state.sketchup_model.selection
 
-          # Get mapping info from selection.
-          mapping = get_mapping_info(state, sketchup_selection)
-
-          state.with_selection_queue(mapping)
-        end
-
-        def self.get_mapping_info(state, selection)
-          group_by_type = selection.group_by(&:class).filter_map do |group|
-            [group.first, group] if MAPPER_SUPPORTED_ENTITY_TYPES.include?(group.first)
-          end.to_h
-          supported_entity_count = group_by_type.length
-
-          # Return empty method list if there is no supported entity to map.
-          return EMPTY_SELECTION if supported_entity_count == 0
-
-          # Return Direct Shape itself if multiple kinds of element are selected like Edge and Face.
-          # OR single type is equal to only direct shape supports.
-          if supported_entity_count > 1 ||
-             (supported_entity_count == 1 &&
-               MAPPER_DIRECT_SHAPE_SUPPORTED_ENTITY_TYPES.include?(group_by_type.keys.first))
-            return direct_shape_selection_info(selection)
-          end
-
-          # Only single type selections remained after this point.
-          return face_selection_info(state, group_by_type) if group_by_type.keys.first == Sketchup::Face
-
-          source_exist = !state.speckle_state.speckle_mapper_state.mapper_source.nil?
-
-          return EMPTY_SELECTION
-        end
-
-        MAPPER_SUPPORTED_ENTITY_TYPES = [
-          Sketchup::ComponentInstance,
-          Sketchup::Group,
-          Sketchup::Face,
-          Sketchup::Edge
-        ].freeze
-
-        MAPPER_DIRECT_SHAPE_SUPPORTED_ENTITY_TYPES = [
-          Sketchup::ComponentInstance,
-          Sketchup::Group
-        ].freeze
-
-        EMPTY_SELECTION = {
-          selection: [],
-          mappingMethods: [],
-          categories: []
-        }.freeze
-
-        def self.direct_shape_selection_info(selection)
-          {
-            selection: SketchupModel::Reader::MapperReader.entities_schema_details(selection),
-            mappingMethods: ['Direct Shape'],
-            categories: Mapper::Category::RevitCategory.to_a
-          }.freeze
-        end
-
-        def self.face_selection_info(state, faces)
-
+          # Collect and return mapper selection info.
+          # Later we can add more selection info for different scopes.
+          MapperSelectionChanged.new(sketchup_selection).update_state(state)
         end
       end
     end

--- a/speckle_connector/src/actions/events/selection_event_action.rb
+++ b/speckle_connector/src/actions/events/selection_event_action.rb
@@ -3,6 +3,7 @@
 require_relative 'event_action'
 require_relative '../../mapper/category/revit_category'
 require_relative '../../sketchup_model/reader/speckle_entities_reader'
+require_relative '../../sketchup_model/reader/mapper_reader'
 require_relative '../../sketchup_model/query/entity'
 
 module SpeckleConnector
@@ -15,17 +16,68 @@ module SpeckleConnector
         def self.update_state(state, event_data)
           return state unless event_data&.any?
 
+          # Get sketchup selection
           sketchup_selection = state.sketchup_state.sketchup_model.selection
-          selection = {
-            selection: SketchupModel::Reader::SpeckleEntitiesReader.entities_schema_details(sketchup_selection),
-            mappingMethods: [
-              'Direct Shape'
-            ],
-            categories: Mapper::Category::RevitCategory.to_a
-          }
-          selection = { selection: [], mappingMethods: [], categories: [] } if sketchup_selection.none?
 
-          state.with_selection_queue(selection)
+          # Get mapping info from selection.
+          mapping = get_mapping_info(state, sketchup_selection)
+
+          state.with_selection_queue(mapping)
+        end
+
+        def self.get_mapping_info(state, selection)
+          group_by_type = selection.group_by(&:class).filter_map do |group|
+            [group.first, group] if MAPPER_SUPPORTED_ENTITY_TYPES.include?(group.first)
+          end.to_h
+          supported_entity_count = group_by_type.length
+
+          # Return empty method list if there is no supported entity to map.
+          return EMPTY_SELECTION if supported_entity_count == 0
+
+          # Return Direct Shape itself if multiple kinds of element are selected like Edge and Face.
+          # OR single type is equal to only direct shape supports.
+          if supported_entity_count > 1 ||
+             (supported_entity_count == 1 &&
+               MAPPER_DIRECT_SHAPE_SUPPORTED_ENTITY_TYPES.include?(group_by_type.keys.first))
+            return direct_shape_selection_info(selection)
+          end
+
+          # Only single type selections remained after this point.
+          return face_selection_info(state, group_by_type) if group_by_type.keys.first == Sketchup::Face
+
+          source_exist = !state.speckle_state.speckle_mapper_state.mapper_source.nil?
+
+          return EMPTY_SELECTION
+        end
+
+        MAPPER_SUPPORTED_ENTITY_TYPES = [
+          Sketchup::ComponentInstance,
+          Sketchup::Group,
+          Sketchup::Face,
+          Sketchup::Edge
+        ].freeze
+
+        MAPPER_DIRECT_SHAPE_SUPPORTED_ENTITY_TYPES = [
+          Sketchup::ComponentInstance,
+          Sketchup::Group
+        ].freeze
+
+        EMPTY_SELECTION = {
+          selection: [],
+          mappingMethods: [],
+          categories: []
+        }.freeze
+
+        def self.direct_shape_selection_info(selection)
+          {
+            selection: SketchupModel::Reader::MapperReader.entities_schema_details(selection),
+            mappingMethods: ['Direct Shape'],
+            categories: Mapper::Category::RevitCategory.to_a
+          }.freeze
+        end
+
+        def self.face_selection_info(state, faces)
+
         end
       end
     end

--- a/speckle_connector/src/actions/load_sketchup_model.rb
+++ b/speckle_connector/src/actions/load_sketchup_model.rb
@@ -3,6 +3,7 @@
 require_relative 'action'
 require_relative 'initialize_materials'
 require_relative '../sketchup_model/reader/speckle_entities_reader'
+require_relative '../sketchup_model/reader/mapper_reader'
 require_relative '../preferences/preferences'
 require_relative '../states/state'
 require_relative '../states/sketchup_state'
@@ -29,7 +30,7 @@ module SpeckleConnector
         new_speckle_entities = SketchupModel::Reader::SpeckleEntitiesReader.read(sketchup_model.entities)
         new_speckle_state = new_state.speckle_state.with_speckle_entities(Immutable::Hash.new(new_speckle_entities))
         # Read mapped entities
-        new_mapped_entities = SketchupModel::Reader::SpeckleEntitiesReader.read_mapped_entities(sketchup_model.entities)
+        new_mapped_entities = SketchupModel::Reader::MapperReader.read_mapped_entities(sketchup_model.entities)
         new_speckle_state = new_speckle_state.with_mapped_entities(Immutable::Hash.new(new_mapped_entities))
         new_state = new_state.with_speckle_state(new_speckle_state)
 

--- a/speckle_connector/src/actions/mapped_entities_updated.rb
+++ b/speckle_connector/src/actions/mapped_entities_updated.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-require_relative '../sketchup_model/reader/speckle_entities_reader'
+require_relative '../sketchup_model/reader/mapper_reader'
 
 module SpeckleConnector
   module Actions
@@ -10,7 +10,7 @@ module SpeckleConnector
       # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
       # @return [States::State] the new updated state object
       def self.update_state(state, _data = nil)
-        mapped_entities = SketchupModel::Reader::SpeckleEntitiesReader
+        mapped_entities = SketchupModel::Reader::MapperReader
                           .mapped_entity_details(state.speckle_state.speckle_mapper_state.mapped_entities.values.to_a)
 
         state.with_mapped_entities_queue(mapped_entities)

--- a/speckle_connector/src/actions/mapper_selection_changed.rb
+++ b/speckle_connector/src/actions/mapper_selection_changed.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+require_relative '../mapper/category/revit_category'
+require_relative '../sketchup_model/reader/mapper_reader'
+require_relative '../sketchup_model/reader/speckle_entities_reader'
+require_relative '../sketchup_model/dictionary/speckle_entity_dictionary_handler'
+
+module SpeckleConnector
+  module Actions
+    # Collects mapper selection info.
+    class MapperSelectionChanged < Action
+      READER = SketchupModel::Reader
+      DICTIONARY = SketchupModel::Dictionary
+
+      def initialize(selection)
+        super()
+        @selection = selection
+      end
+
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @return [States::State] the new updated state object
+      def update_state(state)
+        # Get mapping info from selection.
+        mapping = get_mapping_info(state, @selection)
+
+        state.with_mapper_selection_queue(mapping)
+      end
+
+      def filter_out_levels(selection)
+        selection.reject do |e|
+          DICTIONARY::SpeckleEntityDictionaryHandler
+            .get_attribute(e, :speckle_type) == OBJECTS_BUILTELEMENTS_REVIT_LEVEL
+        end
+      end
+
+      def get_mapping_info(state, selection)
+        selection = filter_out_levels(selection)
+        grouped_by_type = group_by_type(selection)
+
+        supported_entity_count = grouped_by_type.length
+
+        # Return empty method list if there is no supported entity to map.
+        return EMPTY_SELECTION if supported_entity_count == 0
+
+        # Return Direct Shape itself if multiple kinds of element are selected like Edge and Face.
+        # OR single type is equal to only direct shape supports.
+        if supported_entity_count > 1 ||
+           (supported_entity_count == 1 &&
+             MAPPER_DIRECT_SHAPE_SUPPORTED_ENTITY_TYPES.include?(grouped_by_type.keys.first))
+          return direct_shape_selection_info(selection)
+        end
+
+        # Only single type selections remained after this point.
+        return face_selection_info(state, grouped_by_type.values.first) if grouped_by_type.keys.first == Sketchup::Face
+
+        return edge_selection_info(state, grouped_by_type.values.first) if grouped_by_type.keys.first == Sketchup::Edge
+
+        EMPTY_SELECTION
+      end
+
+      MAPPER_SUPPORTED_ENTITY_TYPES = [
+        Sketchup::ComponentInstance,
+        Sketchup::Group,
+        Sketchup::Face,
+        Sketchup::Edge
+      ].freeze
+
+      MAPPER_DIRECT_SHAPE_SUPPORTED_ENTITY_TYPES = [
+        Sketchup::ComponentInstance,
+        Sketchup::Group
+      ].freeze
+
+      EMPTY_SELECTION = {
+        selection: [],
+        mappingMethods: [],
+        categories: []
+      }.freeze
+
+      def direct_shape_selection_info(selection)
+        {
+          selection: SketchupModel::Reader::MapperReader.entities_schema_details(selection),
+          mappingMethods: ['Direct Shape'],
+          categories: Mapper::Category::RevitCategory.to_a
+        }.freeze
+      end
+
+      def direct_shape_selection_info_with_default(selection, methods)
+        {
+          selection: SketchupModel::Reader::MapperReader.entities_schema_details(selection),
+          mappingMethods: ['Direct Shape'] + methods,
+          categories: Mapper::Category::RevitCategory.to_a
+        }.freeze
+      end
+
+      def direct_shape_selection_info_with_source(state, filtered_selection, methods)
+        types = state.speckle_state.speckle_mapper_state.mapper_source.types
+        levels = state.speckle_state.speckle_mapper_state.mapper_source.levels
+        instances = @selection.grep(Sketchup::ComponentInstance)
+        selected_level = instances.find do |i|
+          DICTIONARY::SpeckleEntityDictionaryHandler
+            .get_attribute(i, :speckle_type) == OBJECTS_BUILTELEMENTS_REVIT_LEVEL
+        end
+        selected_level_name = nil
+        if selected_level
+          selected_level_name = DICTIONARY::SpeckleEntityDictionaryHandler.get_attribute(selected_level, :name)
+        end
+        {
+          selection: READER::MapperReader.entities_schema_details(filtered_selection),
+          mappingMethods: ['Direct Shape'] + methods,
+          categories: Mapper::Category::RevitCategory.to_a,
+          types: types,
+          levels: levels,
+          selectedLevel: selected_level_name
+        }.freeze
+      end
+
+      # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      def face_selection_info(state, faces)
+        source_exist = !state.speckle_state.speckle_mapper_state.mapper_source.nil?
+        grouped_by_verticality = faces.group_by { |face| face.normal.perpendicular?(VECTOR_Z) }
+        return direct_shape_selection_info(faces) if grouped_by_verticality.length == 2
+
+        if source_exist
+          if grouped_by_verticality.keys.first
+            direct_shape_selection_info_with_source(state, faces, ['Wall'])
+          else
+            direct_shape_selection_info_with_source(state, faces, ['Floor'])
+          end
+        else
+          if grouped_by_verticality.keys.first
+            direct_shape_selection_info_with_default(faces, ['Default Wall'])
+          else
+            direct_shape_selection_info_with_default(faces, ['Default Floor'])
+          end
+        end
+      end
+
+      def edge_selection_info(state, edges)
+        source_exist = !state.speckle_state.speckle_mapper_state.mapper_source.nil?
+
+        if source_exist
+          methods = ['Column', 'Beam', 'Brace', 'Pipe', 'Duct']
+          direct_shape_selection_info_with_source(state, edges, methods)
+        else
+          default_methods = ['Default Column', 'Default Beam', 'Default Brace', 'Default Pipe', 'Default Duct']
+          direct_shape_selection_info_with_default(edges, default_methods)
+        end
+      end
+
+      def group_by_type_old(selection)
+        selection.group_by(&:class).filter_map do |group|
+          [group.first, group] if MAPPER_SUPPORTED_ENTITY_TYPES.include?(group.first)
+        end.to_h
+      end
+
+      def group_by_type(selection)
+        selection.select { |s| MAPPER_SUPPORTED_ENTITY_TYPES.include?(s.class) }.group_by(&:class)
+      end
+    end
+  end
+end

--- a/speckle_connector/src/actions/mapper_source_updated.rb
+++ b/speckle_connector/src/actions/mapper_source_updated.rb
@@ -44,7 +44,7 @@ module SpeckleConnector
 
       def convert_levels(state, levels)
         levels.collect do |level|
-          SpeckleObjects::BuiltElements::Level.to_native(state, level)
+          SpeckleObjects::BuiltElements::Level.to_native(state, level, @stream_id)
         end
       end
     end

--- a/speckle_connector/src/commands/apply_mappings.rb
+++ b/speckle_connector/src/commands/apply_mappings.rb
@@ -11,9 +11,13 @@ module SpeckleConnector
         entities_to_map = data['entitiesToMap']
         method = data['method']
         category = data['category']
+        family = data['family']
+        family_type = data['familyType']
+        level = data['level']
         name = data['name']
         is_definition = data['isDefinition']
-        action = Actions::ApplyMappings.new(entities_to_map, method, category, name, is_definition)
+        action = Actions::ApplyMappings.new(entities_to_map, method, category, family,
+                                            family_type, level, name, is_definition)
         app.update_state!(action)
       end
     end

--- a/speckle_connector/src/constants/geo_constants.rb
+++ b/speckle_connector/src/constants/geo_constants.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module SpeckleConnector
+  VECTOR_Z = Geom::Vector3d.new(0, 0, 1)
+end

--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -7,8 +7,10 @@ module SpeckleConnector
 
   OBJECTS_BUILTELEMENTS_VIEW3D = 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
   OBJECTS_BUILTELEMENTS_NETWORK = 'Objects.BuiltElements.Network'
-  OBJECTS_BUILTELEMENTS_FLOOR = 'Objects.BuiltElements.Floor'
+  OBJECTS_BUILTELEMENTS_DEFAULT_FLOOR = 'Objects.BuiltElements.Floor'
+  OBJECTS_BUILTELEMENTS_FLOOR = 'Objects.BuiltElements.Floor:Objects.BuiltElements.Revit.RevitFloor'
   OBJECTS_BUILTELEMENTS_REVIT_DIRECTSHAPE = 'Objects.BuiltElements.Revit.DirectShape'
+  OBJECTS_BUILTELEMENTS_REVIT_PARAMETER = 'Objects.BuiltElements.Revit.Parameter'
   OBJECTS_BUILTELEMENTS_REVIT_REVITELEMENTTYPE = 'Objects.BuiltElements.Revit.RevitElementType'
   OBJECTS_BUILTELEMENTS_REVIT_LEVEL = 'Objects.BuiltElements.Level:Objects.BuiltElements.Revit.RevitLevel'
 

--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -15,6 +15,7 @@ require_relative '../speckle_objects/relations/layers'
 require_relative '../speckle_objects/speckle/core/models/model_collection'
 require_relative '../constants/path_constants'
 require_relative '../sketchup_model/reader/speckle_entities_reader'
+require_relative '../sketchup_model/reader/mapper_reader'
 require_relative '../sketchup_model/query/entity'
 
 module SpeckleConnector
@@ -63,7 +64,7 @@ module SpeckleConnector
       def convert(entity, preferences, speckle_state, parent = :base)
         convert = method(:convert)
 
-        unless SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entity)
+        unless SketchupModel::Reader::MapperReader.mapped_with_schema?(entity)
           return from_native_to_speckle(entity, preferences, speckle_state, parent, &convert)
         end
 

--- a/speckle_connector/src/convertors/to_speckle.rb
+++ b/speckle_connector/src/convertors/to_speckle.rb
@@ -73,7 +73,7 @@ module SpeckleConnector
 
       def from_mapped_to_speckle(entity, path, preferences)
         direct_shape = SpeckleObjects::BuiltElements::Revit::DirectShape
-                       .from_entity(entity, path, @units, preferences)
+                       .from_entity(speckle_state, entity, path, @units, preferences)
         return [direct_shape, [entity]]
       end
 
@@ -85,7 +85,7 @@ module SpeckleConnector
         end
 
         if entity.is_a?(Sketchup::Face)
-          mesh = SpeckleObjects::Geometry::Mesh.from_face(face: entity, units: @units,
+          mesh = SpeckleObjects::Geometry::Mesh.from_face(speckle_state: speckle_state, face: entity, units: @units,
                                                           model_preferences: preferences[:model])
           return speckle_state, [mesh, [entity]]
         end

--- a/speckle_connector/src/mapper/mapper.rb
+++ b/speckle_connector/src/mapper/mapper.rb
@@ -2,7 +2,7 @@
 
 require_relative '../speckle_objects/built_elements/floor'
 require_relative '../sketchup_model/query/entity'
-require_relative '../sketchup_model/reader/speckle_entities_reader'
+require_relative '../sketchup_model/reader/mapper_reader'
 require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
 
 module SpeckleConnector
@@ -17,9 +17,9 @@ module SpeckleConnector
       mapped_selection = []
       flat_selection_with_path.each do |entities|
         entity = entities[0]
-        is_entity_mapped = SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entity)
+        is_entity_mapped = SketchupModel::Reader::MapperReader.mapped_with_schema?(entity)
         if entity.respond_to?(:definition)
-          is_definition_mapped = SketchupModel::Reader::SpeckleEntitiesReader.mapped_with_schema?(entity.definition)
+          is_definition_mapped = SketchupModel::Reader::MapperReader.mapped_with_schema?(entity.definition)
           mapped_selection.append(entities) if is_entity_mapped || is_definition_mapped
           next
         end

--- a/speckle_connector/src/mapper/mapper.rb
+++ b/speckle_connector/src/mapper/mapper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../speckle_objects/built_elements/floor'
+require_relative '../speckle_objects/built_elements/default_floor'
 require_relative '../sketchup_model/query/entity'
 require_relative '../sketchup_model/reader/mapper_reader'
 require_relative '../sketchup_model/dictionary/speckle_schema_dictionary_handler'
@@ -28,12 +29,18 @@ module SpeckleConnector
       mapped_selection
     end
 
-    def self.to_speckle(entity, units, global_transformation: nil)
+    def self.to_speckle(speckle_state, entity, units, global_transformation: nil)
       speckle_schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(entity)
       return speckle_schema if speckle_schema.nil?
 
       if speckle_schema['method'] == 'Default Floor'
-        return SpeckleObjects::BuiltElements::Floor.to_speckle_schema(entity, units, global_transformation: global_transformation)
+        return SpeckleObjects::BuiltElements::DefaultFloor
+               .to_speckle_schema(entity, units, global_transformation: global_transformation)
+      end
+
+      if speckle_schema['method'] == 'Floor'
+        return SpeckleObjects::BuiltElements::Floor
+               .to_speckle_schema(speckle_state, entity, units, global_transformation: global_transformation)
       end
 
       return speckle_schema

--- a/speckle_connector/src/sketchup_model/reader/mapper_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/mapper_reader.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative '../dictionary/speckle_schema_dictionary_handler'
+require_relative '../../speckle_entities/speckle_entity'
+require_relative '../../mapper/category/revit_category'
+require_relative '../../constants/dict_constants'
+
+module SpeckleConnector
+  # Operations related to {SketchupModel}.
+  module SketchupModel
+    # Reader model for sketchup model.
+    module Reader
+      # Reader module for mapper.
+      module MapperReader
+        # @param entities [Sketchup::Entities] entities to collect mapped entities.
+        # @return [Hash{String=>Sketchup::Entity}] mapped entities with persistent id.
+        def self.read_mapped_entities(entities)
+          mapped_entities = {}
+          Query::Entity.flat_entities(entities).each do |entity|
+            mapped_entities[entity.persistent_id] = entity if mapped_with_schema?(entity)
+          end
+          mapped_entities
+        end
+
+        # @param entity [Sketchup::Entity] sketchup entity to check whether mapped with speckle schema or not.
+        def self.mapped_with_schema?(entity)
+          is_entity_mapped = !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity).nil?
+          return is_entity_mapped if is_entity_mapped
+          return is_entity_mapped unless entity.is_a?(Sketchup::ComponentInstance)
+
+          !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity.definition).nil?
+        end
+
+        def self.get_schema(entity)
+          Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(entity)
+        end
+
+        def self.entities_schema_details(entities)
+          entities.collect do |entity|
+            entity_selection_details = entity_selection_details(entity)
+            if entity.is_a?(Sketchup::ComponentInstance)
+              entity_selection_details = entity_selection_details.merge(
+                { definition: entity_selection_details(entity.definition) }
+              )
+            end
+            entity_selection_details
+          end
+        end
+
+        def self.entity_selection_details(entity)
+          sanitized_type = entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split
+          is_definition = entity.is_a?(Sketchup::ComponentDefinition)
+          entity_type = is_definition ? sanitized_type.last : sanitized_type.first
+          speckle_schema = get_schema(entity)
+          {
+            name: speckle_schema['name'],
+            entityName: entity.respond_to?(:name) ? entity.name : '',
+            entityId: entity.persistent_id,
+            entityType: entity_type,
+            schema: speckle_schema,
+            numberOfInstances: is_definition ? entity.instances.length : 1
+          }
+        end
+
+        def self.mapped_entity_details(entities)
+          reverse_category_dictionary = Mapper::Category::RevitCategory.reverse_dictionary
+          entities.collect do |entity|
+            speckle_schema = get_schema(entity)
+            speckle_schema_definition = entity.respond_to?(:definition) ? get_schema(entity.definition) : nil
+            entity_type = entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split.first
+            category = get_map_attribute(speckle_schema, speckle_schema_definition, 'category')
+            {
+              name: get_map_attribute(speckle_schema, speckle_schema_definition, 'name'),
+              category: category,
+              categoryName: category.nil? ? '' : reverse_category_dictionary[category],
+              method: get_map_attribute(speckle_schema, speckle_schema_definition, 'method'),
+              entityName: entity.respond_to?(:name) ? entity.name : '',
+              entityId: entity.persistent_id,
+              entityType: entity.is_a?(Sketchup::ComponentDefinition) ? 'Definition' : entity_type,
+              schema: speckle_schema,
+              definitionSchema: speckle_schema_definition
+            }
+          end
+        end
+
+        def self.get_map_attribute(schema, definition_schema, attribute)
+          return schema[attribute] if schema[attribute]
+          return definition_schema[attribute] if !definition_schema.nil? && definition_schema[attribute]
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
+++ b/speckle_connector/src/sketchup_model/reader/speckle_entities_reader.rb
@@ -29,16 +29,6 @@ module SpeckleConnector
           speckle_entities
         end
 
-        # @param entities [Sketchup::Entities] entities to collect mapped entities.
-        # @return [Hash{String=>Sketchup::Entity}] mapped entities with persistent id.
-        def self.read_mapped_entities(entities)
-          mapped_entities = {}
-          Query::Entity.flat_entities(entities).each do |entity|
-            mapped_entities[entity.persistent_id] = entity if mapped_with_schema?(entity)
-          end
-          mapped_entities
-        end
-
         # @param entity [Sketchup::Entity] sketchup entity to read from attribute dictionary.
         def self.read_speckle_entity(entity)
           dict = entity.attribute_dictionaries.to_a.find { |d| d.name == SPECKLE_BASE_OBJECT }
@@ -60,73 +50,7 @@ module SpeckleConnector
           entity.attribute_dictionaries.to_a.any? { |dict| dict.name == SPECKLE_BASE_OBJECT }
         end
 
-        # @param entity [Sketchup::Entity] sketchup entity to check whether mapped with speckle schema or not.
-        def self.mapped_with_schema?(entity)
-          is_entity_mapped = !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity).nil?
-          return is_entity_mapped if is_entity_mapped
-          return is_entity_mapped unless entity.is_a?(Sketchup::ComponentInstance)
 
-          !Dictionary::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity.definition).nil?
-        end
-
-        def self.get_schema(entity)
-          Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(entity)
-        end
-
-        def self.entities_schema_details(entities)
-          entities.collect do |entity|
-            entity_selection_details = entity_selection_details(entity)
-            if entity.is_a?(Sketchup::ComponentInstance)
-              entity_selection_details = entity_selection_details.merge(
-                { definition: entity_selection_details(entity.definition) }
-              )
-            end
-            entity_selection_details
-          end
-        end
-
-        def self.entity_selection_details(entity)
-          sanitized_type = entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split
-          is_definition = entity.is_a?(Sketchup::ComponentDefinition)
-          entity_type = is_definition ? sanitized_type.last : sanitized_type.first
-          speckle_schema = get_schema(entity)
-          {
-            name: speckle_schema['name'],
-            entityName: entity.respond_to?(:name) ? entity.name : '',
-            entityId: entity.persistent_id,
-            entityType: entity_type,
-            schema: speckle_schema,
-            numberOfInstances: is_definition ? entity.instances.length : 1
-          }
-        end
-
-        def self.mapped_entity_details(entities)
-          reverse_category_dictionary = Mapper::Category::RevitCategory.reverse_dictionary
-          entities.collect do |entity|
-            speckle_schema = get_schema(entity)
-            speckle_schema_definition = entity.respond_to?(:definition) ? get_schema(entity.definition) : nil
-            entity_type = entity.class.name.split('::').last.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').split.first
-            category = get_map_attribute(speckle_schema, speckle_schema_definition, 'category')
-            {
-              name: get_map_attribute(speckle_schema, speckle_schema_definition, 'name'),
-              category: category,
-              categoryName: category.nil? ? '' : reverse_category_dictionary[category],
-              method: get_map_attribute(speckle_schema, speckle_schema_definition, 'method'),
-              entityName: entity.respond_to?(:name) ? entity.name : '',
-              entityId: entity.persistent_id,
-              entityType: entity.is_a?(Sketchup::ComponentDefinition) ? 'Definition' : entity_type,
-              schema: speckle_schema,
-              definitionSchema: speckle_schema_definition
-            }
-          end
-        end
-
-        def self.get_map_attribute(schema, definition_schema, attribute)
-          return schema[attribute] if schema[attribute]
-          return definition_schema[attribute] if !definition_schema.nil? && definition_schema[attribute]
-
-          nil
-        end
       end
     end
   end

--- a/speckle_connector/src/sketchup_model/utils/face_utils.rb
+++ b/speckle_connector/src/sketchup_model/utils/face_utils.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../constants/geo_constants'
+
 module SpeckleConnector
   # Operations related to {SketchupModel}.
   module SketchupModel
@@ -23,6 +25,16 @@ module SpeckleConnector
             edges_ary = new_faces.collect(&:edges).flatten.uniq - edges_ary
           end
           adj_faces.uniq
+        end
+
+        # @param face [Sketchup::Face] face to check whether is vertical or not.
+        def self.vertical?(face)
+          face.normal.perpendicular?(VECTOR_Z)
+        end
+
+        # @param face [Sketchup::Face] face to check whether is horizontal or not.
+        def self.horizontal?(face)
+          face.normal.parallel?(VECTOR_Z)
         end
       end
     end

--- a/speckle_connector/src/speckle_objects/built_elements/default_floor.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/default_floor.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../built_elements/revit/parameter'
+require_relative '../other/render_material'
+require_relative '../geometry/line'
+require_relative '../geometry/polyline'
+require_relative '../../constants/type_constants'
+require_relative '../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module BuiltElements
+      # Default Floor object.
+      class DefaultFloor < Base
+        SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_DEFAULT_FLOOR
+
+        def initialize(outline:, voids:, units:, material:, application_id: nil)
+          super(
+            speckle_type: SPECKLE_TYPE,
+            total_children_count: 0,
+            application_id: application_id,
+            id: nil
+          )
+          self[:outline] = outline
+          self[:voids] = voids
+          self[:units] = units
+          self[:renderMaterial] = material
+        end
+
+        # @param face [Sketchup::Face] face to get speckle schema for floor.
+        def self.to_speckle_schema(face, units, global_transformation: nil)
+          outline = Geometry::Polyline.from_loop(face.loops.first, units, global_transformation: global_transformation)
+          voids = []
+          if face.loops.length > 1
+            voids = face.loops[1..face.loops.length - 1].collect do |loop|
+              Geometry::Polyline.from_loop(loop, units, global_transformation: global_transformation)
+            end
+          end
+          material = face.material || face.back_material
+
+          DefaultFloor.new(
+            outline: outline,
+            voids: voids,
+            units: units,
+            material: material.nil? ? nil : Other::RenderMaterial.from_material(face.material || face.back_material),
+            application_id: face.persistent_id
+          )
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/built_elements/floor.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/floor.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative '../built_elements/revit/parameter'
 require_relative '../other/render_material'
 require_relative '../geometry/line'
 require_relative '../geometry/polyline'
 require_relative '../../constants/type_constants'
+require_relative '../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
 
 module SpeckleConnector
   module SpeckleObjects
@@ -13,21 +15,25 @@ module SpeckleConnector
       class Floor < Base
         SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_FLOOR
 
-        def initialize(outline:, voids:, units:, material:, application_id: nil)
+        def initialize(family:, type:, outline:, voids:, level:, units:, material:, parameters:nil, application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
             total_children_count: 0,
             application_id: application_id,
             id: nil
           )
+          self[:family] = family
+          self[:type] = type
+          self[:level] = level
           self[:outline] = outline
           self[:voids] = voids
           self[:units] = units
+          self[:parameters] = parameters
           self[:renderMaterial] = material
         end
 
         # @param face [Sketchup::Face] face to get speckle schema for floor.
-        def self.to_speckle_schema(face, units, global_transformation: nil)
+        def self.to_speckle_schema(speckle_state, face, units, global_transformation: nil)
           outline = Geometry::Polyline.from_loop(face.loops.first, units, global_transformation: global_transformation)
           voids = []
           if face.loops.length > 1
@@ -36,12 +42,31 @@ module SpeckleConnector
             end
           end
           material = face.material || face.back_material
+          schema = SketchupModel::Dictionary::SpeckleSchemaDictionaryHandler.speckle_schema_to_speckle(face).to_h
+          source_exist = !speckle_state.speckle_mapper_state.mapper_source.nil?
+          level = nil
+          parameters = nil
+          if source_exist
+            level = speckle_state.speckle_mapper_state.mapper_source.levels.find { |l| l[:name] == schema['level'] }
+            parameters = Base.new
+            offset_parameter = BuiltElements::Revit::Parameter.new(name: 'Height Offset From Level')
+            level_z = Geometry.length_to_native(level[:elevation], level[:units])
+            min_z = face.vertices.collect(&:position).map(&:z).min
+            offset_parameter['value'] = Geometry.length_to_speckle(min_z - level_z, units)
+            offset_parameter['units'] = units
+            parameters['Height Offset From Level'] = offset_parameter
+          end
+
           Floor.new(
+            family: schema['family'],
+            type: schema['family_type'],
             outline: outline,
             voids: voids,
+            level: level,
             units: units,
+            parameters: parameters,
             material: material.nil? ? nil : Other::RenderMaterial.from_material(face.material || face.back_material),
-            application_id: face.entityID
+            application_id: face.persistent_id
           )
         end
       end

--- a/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
@@ -89,7 +89,7 @@ module SpeckleConnector
             mapped_selection
           end
 
-          def self.from_entity(entity, path, units, preferences)
+          def self.from_entity(speckle_state, entity, path, units, preferences)
             schema = DICTIONARY::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity)
             if schema.nil? && entity.respond_to?(:definition)
               schema = DICTIONARY::SpeckleSchemaDictionaryHandler.attribute_dictionary(entity.definition)
@@ -103,7 +103,7 @@ module SpeckleConnector
                                       entity.definition.entities, [Sketchup::Face], path.append(entity)
                                     )
             end
-            base_geometries = group_faces_under_mesh_by_material(entities_with_path, units, preferences)
+            base_geometries = group_faces_under_mesh_by_material(speckle_state, entities_with_path, units, preferences)
             DirectShape.new(
               name: schema[:name], category: schema[:category], units: units,
               base_geometries: base_geometries, application_id: entity.persistent_id
@@ -111,7 +111,7 @@ module SpeckleConnector
           end
 
           # rubocop:disable Metrics/MethodLength
-          def self.group_faces_under_mesh_by_material(faces_with_path, units, preferences)
+          def self.group_faces_under_mesh_by_material(speckle_state, faces_with_path, units, preferences)
             mesh_groups = {}
             faces_with_path.each do |face_with_path|
               face = face_with_path[0]
@@ -125,6 +125,7 @@ module SpeckleConnector
                 mesh_group[1].append(face)
               else
                 mesh = Geometry::Mesh.from_face(
+                  speckle_state: speckle_state,
                   face: face, units: units, model_preferences: preferences[:model],
                   global_transform: QUERY::Entity.global_transformation(face, entity_path),
                   parent_material: parent_material

--- a/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/direct_shape.rb
@@ -7,7 +7,7 @@ require_relative '../../other/block_definition'
 require_relative '../../other/transform'
 require_relative '../../../constants/type_constants'
 require_relative '../../../sketchup_model/query/entity'
-require_relative '../../../sketchup_model/reader/speckle_entities_reader'
+require_relative '../../../sketchup_model/reader/mapper_reader'
 require_relative '../../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
 
 module SpeckleConnector
@@ -78,9 +78,9 @@ module SpeckleConnector
             mapped_selection = []
             flat_selection_with_path.each do |entities|
               entity = entities[0]
-              is_entity_mapped = READER::SpeckleEntitiesReader.mapped_with_schema?(entity)
+              is_entity_mapped = READER::MapperReader.mapped_with_schema?(entity)
               if entity.respond_to?(:definition)
-                is_definition_mapped = READER::SpeckleEntitiesReader.mapped_with_schema?(entity.definition)
+                is_definition_mapped = READER::MapperReader.mapped_with_schema?(entity.definition)
                 mapped_selection.append(entities) if is_entity_mapped || is_definition_mapped
                 next
               end

--- a/speckle_connector/src/speckle_objects/built_elements/revit/parameter.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/parameter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../../base'
+require_relative '../../../constants/type_constants'
+
+module SpeckleConnector
+  module SpeckleObjects
+    module BuiltElements
+      module Revit
+        # Revit parameter.
+        class Parameter < Base
+          SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_REVIT_PARAMETER
+          def initialize(name:, application_id: nil)
+            super(
+              speckle_type: SPECKLE_TYPE,
+              total_children_count: 0,
+              application_id: application_id,
+              id: id
+            )
+            self[:name] = name
+          end
+        end
+      end
+    end
+  end
+end

--- a/speckle_connector/src/speckle_objects/geometry/mesh.rb
+++ b/speckle_connector/src/speckle_objects/geometry/mesh.rb
@@ -148,13 +148,13 @@ module SpeckleConnector
         # @param global_transform [Geom::Transformation, nil] global transformation value of face if it is not included
         #  into any component.
         # rubocop:disable Style/MultilineTernaryOperator
-        def self.from_face(face:, units:, model_preferences:, global_transform: nil, parent_material: nil)
+        def self.from_face(speckle_state:, face:, units:, model_preferences:, global_transform: nil, parent_material: nil)
           dictionaries = SketchupModel::Dictionary::BaseDictionaryHandler
                          .attribute_dictionaries_to_speckle(face, model_preferences)
           has_any_soften_edge = face.edges.any?(&:soft?)
           att = dictionaries.any? ? { is_soften: has_any_soften_edge, dictionaries: dictionaries }
                   : { is_soften: has_any_soften_edge }
-          speckle_schema = Mapper.to_speckle(face, units, global_transformation: global_transform)
+          speckle_schema = Mapper.to_speckle(speckle_state, face, units, global_transformation: global_transform)
           material = face.material || face.back_material || parent_material
           speckle_mesh = Mesh.new(
             units: units,

--- a/speckle_connector/src/states/speckle_state.rb
+++ b/speckle_connector/src/states/speckle_state.rb
@@ -69,13 +69,13 @@ module SpeckleConnector
         with(:@message_queue => new_queue)
       end
 
-      def with_selection_queue(selection_parameters)
+      def with_mapper_selection_queue(selection_parameters)
         new_queue = message_queue.merge({ "entitySelected":
                                             "entitySelected(#{JSON.generate(selection_parameters)})" })
         with(:@message_queue => new_queue)
       end
 
-      def with_deselection_queue
+      def with_mapper_deselection_queue
         new_queue = message_queue.merge({ "entitiesDeselected": 'entitiesDeselected()' })
         with(:@message_queue => new_queue)
       end
@@ -98,6 +98,11 @@ module SpeckleConnector
 
       def with_mapper_source(mapper_source)
         new_speckle_mapper_state = speckle_mapper_state.with_mapper_source(mapper_source)
+        with(:@speckle_mapper_state => new_speckle_mapper_state)
+      end
+
+      def with_removed_mapper_source
+        new_speckle_mapper_state = speckle_mapper_state.with_mapper_source(nil)
         with(:@speckle_mapper_state => new_speckle_mapper_state)
       end
 

--- a/speckle_connector/src/states/state.rb
+++ b/speckle_connector/src/states/state.rb
@@ -41,11 +41,11 @@ module SpeckleConnector
         with(:@speckle_state => new_speckle_state)
       end
 
-      def with_selection_queue(selection_parameters)
+      def with_mapper_selection_queue(selection_parameters)
         new_speckle_state = if selection_parameters[:selection].any?
-                              speckle_state.with_selection_queue(selection_parameters)
+                              speckle_state.with_mapper_selection_queue(selection_parameters)
                             else
-                              speckle_state.with_deselection_queue
+                              speckle_state.with_mapper_deselection_queue
                             end
         with(:@speckle_state => new_speckle_state)
       end

--- a/speckle_connector/src/ui/vue_view.rb
+++ b/speckle_connector/src/ui/vue_view.rb
@@ -30,6 +30,7 @@ require_relative '../actions/isolate_mappings_from_table'
 require_relative '../actions/hide_mappings_from_table'
 require_relative '../actions/select_mappings_from_table'
 require_relative '../actions/show_all_entities'
+require_relative '../actions/clear_mapper_source'
 
 module SpeckleConnector
   module Ui
@@ -91,7 +92,8 @@ module SpeckleConnector
           hide_mappings_from_table: Commands::ActionCommand.new(@app, Actions::HideMappingsFromTable),
           select_mappings_from_table: Commands::ActionCommand.new(@app, Actions::SelectMappingsFromTable),
           show_all_entities: Commands::ActionCommand.new(@app, Actions::ShowAllEntities),
-          mapper_source_updated: Commands::MapperSourceUpdated.new(@app)
+          mapper_source_updated: Commands::MapperSourceUpdated.new(@app),
+          clear_mapper_source: Commands::ActionCommand.new(@app, Actions::ClearMapperSource)
         }.freeze
       end
       # rubocop:enable Metrics/MethodLength

--- a/ui/src/components/Mapper.vue
+++ b/ui/src/components/Mapper.vue
@@ -275,6 +275,7 @@ export default {
       entitySelected: false,
       selectedEntityCount: 0,
       selectedEntities: [],
+      familyTypes: {},
       lastSelectedEntity: null,
       selectedMethod: null,
       selectedCategory: null,
@@ -560,6 +561,7 @@ export default {
       this.enabledMethods = selectionPars.mappingMethods
       this.availableCategories = selectionPars.categories
       this.selectedEntities = selectionPars.selection
+      this.familyTypes = selectionPars.familyTypes
       this.lastSelectedEntity = this.selectedEntities[this.selectedEntities.length - 1]
       this.entityMapped = this.isEntitiesMapped(this.selectedEntities)
       this.definitionMapped = this.isEntityDefinitionsMapped(this.selectedEntities)

--- a/ui/src/components/MapperSource.vue
+++ b/ui/src/components/MapperSource.vue
@@ -18,8 +18,34 @@
         item-text="name"
         item-value="id"
         density="compact"
-        @change="onSourceBranchChanged"
     ></v-autocomplete>
+
+    <v-container class="pa-0 mt-2">
+      <v-row justify="center" align="center">
+        <v-col cols="auto" class="pa-1 pb-2">
+          <v-btn
+              small
+              @click="applySource"
+          >
+            <v-icon dark left>
+              mdi-checkbox-marked-circle
+            </v-icon>Apply
+          </v-btn>
+        </v-col>
+        <v-col cols="auto" class="pa-1 pb-2">
+          <v-btn
+              small
+              :disabled="!sourceApplied"
+              @click="clearSource"
+          >
+            <v-icon dark left>
+              mdi-close-circle
+            </v-icon>Clear
+          </v-btn>
+        </v-col>
+      </v-row>
+
+    </v-container>
   </v-container>
 </template>
 
@@ -40,6 +66,7 @@ export default {
   },
   data() {
     return {
+      sourceApplied: false,
       sourceStreamId: null,
       sourceBranchId: null,
       sourceStreamName: null,
@@ -88,12 +115,14 @@ export default {
             streamId: this.sourceStreamId
           }
         },
-        result() {
-          this.afterCommitCreated()
+        result(data) {
+          if (data.data.commitCreated.sourceApplication.includes('Revit')){
+            this.afterCommitCreated()
             this.$eventHub.$emit('notification', {
-                text: `A new commit was created on source stream!`,
+              text: `A new commit was created on Revit!`,
             })
-          this.$apollo.queries.stream.refetch()
+            this.$apollo.queries.stream.refetch()
+          }
         },
         skip() {
             // Return true to skip the initial query execution
@@ -136,6 +165,13 @@ export default {
     })
   },
   methods: {
+    applySource(){
+      this.onSourceBranchChanged()
+    },
+    clearSource(){
+      sketchup.exec({name:"clear_mapper_source" , data: {}})
+      this.sourceApplied = false
+    },
     afterCommitCreated(){
       bus.$emit('set-source-up-to-date', false)
     },
@@ -156,6 +192,7 @@ export default {
           stream_id: this.sourceStreamId,
           commit_id: commitRefId
         }})
+      this.sourceApplied = true
     }
   }
 }


### PR DESCRIPTION
Now we can filter methods according to selected object types and existence of mapper source. The test case of this functionality can be done with `Floor` and `Default Floor` creation. Another improvement is calculating offset value from assigned level and min z value of the face. Once we receive Floors on Revit, they are created at correct elevation. 