### PR TITLE
Chore (Mapper): Rename Floor with RevitFloor

### DIFF
--- a/speckle_connector/src/constants/type_constants.rb
+++ b/speckle_connector/src/constants/type_constants.rb
@@ -7,12 +7,14 @@ module SpeckleConnector
 
   OBJECTS_BUILTELEMENTS_VIEW3D = 'Objects.BuiltElements.View:Objects.BuiltElements.View3D'
   OBJECTS_BUILTELEMENTS_NETWORK = 'Objects.BuiltElements.Network'
+  OBJECTS_BUILTELEMENTS_REVIT_LEVEL = 'Objects.BuiltElements.Level:Objects.BuiltElements.Revit.RevitLevel'
   OBJECTS_BUILTELEMENTS_DEFAULT_FLOOR = 'Objects.BuiltElements.Floor'
-  OBJECTS_BUILTELEMENTS_FLOOR = 'Objects.BuiltElements.Floor:Objects.BuiltElements.Revit.RevitFloor'
+  OBJECTS_BUILTELEMENTS_REVIT_FLOOR = 'Objects.BuiltElements.Floor:Objects.BuiltElements.Revit.RevitFloor'
+  OBJECTS_BUILTELEMENTS_DEFAULT_WALL = 'Objects.BuiltElements.Wall'
+  OBJECTS_BUILTELEMENTS_REVIT_WALL = 'Objects.BuiltElements.Wall:Objects.BuiltElements.Revit.RevitWall'
   OBJECTS_BUILTELEMENTS_REVIT_DIRECTSHAPE = 'Objects.BuiltElements.Revit.DirectShape'
   OBJECTS_BUILTELEMENTS_REVIT_PARAMETER = 'Objects.BuiltElements.Revit.Parameter'
   OBJECTS_BUILTELEMENTS_REVIT_REVITELEMENTTYPE = 'Objects.BuiltElements.Revit.RevitElementType'
-  OBJECTS_BUILTELEMENTS_REVIT_LEVEL = 'Objects.BuiltElements.Level:Objects.BuiltElements.Revit.RevitLevel'
 
   OBJECTS_GEOMETRY_LINE = 'Objects.Geometry.Line'
   OBJECTS_GEOMETRY_POLYLINE = 'Objects.Geometry.Polyline'

--- a/speckle_connector/src/mapper/mapper.rb
+++ b/speckle_connector/src/mapper/mapper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../speckle_objects/built_elements/floor'
+require_relative '../speckle_objects/built_elements/revit/revit_floor'
 require_relative '../speckle_objects/built_elements/default_floor'
 require_relative '../sketchup_model/query/entity'
 require_relative '../sketchup_model/reader/mapper_reader'
@@ -39,7 +39,7 @@ module SpeckleConnector
       end
 
       if speckle_schema['method'] == 'Floor'
-        return SpeckleObjects::BuiltElements::Floor
+        return SpeckleObjects::BuiltElements::RevitFloor
                .to_speckle_schema(speckle_state, entity, units, global_transformation: global_transformation)
       end
 

--- a/speckle_connector/src/speckle_objects/built_elements/revit/revit_floor.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/revit_floor.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
-require_relative '../base'
-require_relative '../built_elements/revit/parameter'
-require_relative '../other/render_material'
-require_relative '../geometry/line'
-require_relative '../geometry/polyline'
-require_relative '../../constants/type_constants'
-require_relative '../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
+require_relative '../../base'
+require_relative '../../built_elements/revit/parameter'
+require_relative '../../other/render_material'
+require_relative '../../geometry/line'
+require_relative '../../geometry/polyline'
+require_relative '../../../constants/type_constants'
+require_relative '../../../sketchup_model/dictionary/speckle_schema_dictionary_handler'
 
 module SpeckleConnector
   module SpeckleObjects
     module BuiltElements
-      # Floor object.
-      class Floor < Base
-        SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_FLOOR
+      # Revit floor object.
+      class RevitFloor < Base
+        SPECKLE_TYPE = OBJECTS_BUILTELEMENTS_REVIT_FLOOR
 
+        # rubocop:disable Metrics/ParameterLists
         def initialize(family:, type:, outline:, voids:, level:, units:, material:, parameters:nil, application_id: nil)
           super(
             speckle_type: SPECKLE_TYPE,
@@ -31,6 +32,7 @@ module SpeckleConnector
           self[:parameters] = parameters
           self[:renderMaterial] = material
         end
+        # rubocop:enable Metrics/ParameterLists
 
         # @param face [Sketchup::Face] face to get speckle schema for floor.
         def self.to_speckle_schema(speckle_state, face, units, global_transformation: nil)
@@ -57,7 +59,7 @@ module SpeckleConnector
             parameters['Height Offset From Level'] = offset_parameter
           end
 
-          Floor.new(
+          RevitFloor.new(
             family: schema['family'],
             type: schema['family_type'],
             outline: outline,


### PR DESCRIPTION
Correct naming for native `RevitFloor` instead just `Floor`.