### PR TITLE
Fix (Mapper): Definition mapping

### DIFF
--- a/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
@@ -84,7 +84,7 @@ module SpeckleConnector
 
               method = SPECKLE_SCHEMA_DICTIONARY_HANDLER.get_attribute(entity, 'method')
 
-              if (method.include?('Floor') || method.include?('Wall')) && entity.is_a?(Sketchup::Face)
+              if !method.nil? && (method.include?('Floor') || method.include?('Wall')) && entity.is_a?(Sketchup::Face)
                 global_transformation = QUERY::Entity.global_transformation(entity, path)
                 floor = SpeckleObjects::Geometry::Mesh.from_face(speckle_state: speckle_state, face: entity,
                                                                  units: units, model_preferences: preferences,


### PR DESCRIPTION
There is a regression on definition mappings after new method implementations. Solution is a basic nil check.