### PR TITLE
Fix (Revit): Support curtain walls from revit

### DIFF
--- a/speckle_connector/src/convertors/to_native.rb
+++ b/speckle_connector/src/convertors/to_native.rb
@@ -56,6 +56,7 @@ module SpeckleConnector
       BLOCK_DEFINITION = OTHER::BlockDefinition
       BLOCK_INSTANCE = OTHER::BlockInstance
       REVIT_INSTANCE = REVIT::Other::RevitInstance
+      REVIT_WALL = BUILTELEMENTS::RevitWall
       RENDER_MATERIAL = OTHER::RenderMaterial
       DISPLAY_VALUE = OTHER::DisplayValue
       VIEW3D = BUILTELEMENTS::View3d
@@ -77,6 +78,7 @@ module SpeckleConnector
         Objects.Other.RenderMaterial
         Objects.Other.Instance:Objects.Other.BlockInstance
         Objects.BuiltElements.View:Objects.BuiltElements.View3D
+        Objects.BuiltElements.Wall:Objects.BuiltElements.Revit.RevitWall
         Objects.BuiltElements.Network
         Objects.GIS.PolygonElement
         Speckle.Core.Models.Collection
@@ -294,6 +296,7 @@ module SpeckleConnector
         OBJECTS_OTHER_REVIT_REVITINSTANCE => REVIT_INSTANCE.method(:to_native),
         OBJECTS_OTHER_RENDERMATERIAL => RENDER_MATERIAL.method(:to_native),
         OBJECTS_BUILTELEMENTS_VIEW3D => VIEW3D.method(:to_native),
+        OBJECTS_BUILTELEMENTS_REVIT_WALL => REVIT_WALL.method(:to_native),
         OBJECTS_BUILTELEMENTS_REVIT_DIRECTSHAPE => BUILTELEMENTS::Revit::DirectShape.method(:to_native),
         OBJECTS_BUILTELEMENTS_NETWORK => BUILTELEMENTS::Network.method(:to_native),
         OBJECTS_GIS_POLYGONELEMENT => POLYGON_ELEMENT.method(:to_native),

--- a/speckle_connector/src/speckle_objects/built_elements/revit/revit_wall.rb
+++ b/speckle_connector/src/speckle_objects/built_elements/revit/revit_wall.rb
@@ -36,6 +36,27 @@ module SpeckleConnector
         end
         # rubocop:enable Metrics/ParameterLists
 
+        def self.to_native(state, wall, layer, entities, &convert_to_native)
+          obj = Other::DisplayValue.collect_definition_geometries(wall)
+          obj['name'] = Other::DisplayValue.get_definition_name(obj)
+
+          state, _definitions = Other::BlockDefinition.to_native(
+            state, obj, layer, entities, &convert_to_native
+          )
+
+          definition = state.sketchup_state.sketchup_model.definitions[Other::BlockDefinition.get_definition_name(obj)]
+
+          Other::BlockInstance.find_and_erase_existing_instance(definition, obj['id'], obj['applicationId'])
+          t_arr = obj['transform']
+          transform = t_arr.nil? ? Geom::Transformation.new : Other::Transform.to_native(t_arr, obj['units'])
+          instance = entities.add_instance(definition, transform)
+          instance.name = Other::DisplayValue.get_instance_name(obj['name']) unless obj['name'].nil?
+          instance.layer = layer unless layer.nil?
+          # Align instance axes that created from display value. (without any transform)
+          # BlockInstance.align_instance_axes(instance)
+          return state, [instance, definition]
+        end
+
         # @param face [Sketchup::Face] face to get speckle schema for wall.
         def self.to_speckle_schema(speckle_state, face, units, global_transformation: nil)
           base_line = Geometry::Line.base_line_from_face(face, units, global_transformation: global_transformation)

--- a/speckle_connector/src/speckle_objects/other/display_value.rb
+++ b/speckle_connector/src/speckle_objects/other/display_value.rb
@@ -83,13 +83,19 @@ module SpeckleConnector
 
           elements = obj['elements'] || obj['@elements']
 
-          if !elements.nil? && elements.is_a?(Array)
-            elements.each do |element|
-              # Mullions is a special case here, they are extracted as base object with @displayValue from revit..
-              if element['@displayValue'].nil?
-                obj['geometry'].append(element)
-              else
-                obj['geometry'] += element['@displayValue']
+          # if only elements are there then assign only elements, there are some cases that RevitWalls can only
+          # have elements instead of display value
+          if obj['geometry'].nil? && !elements.nil?
+            obj['geometry'] = elements
+          else
+            if !elements.nil? && elements.is_a?(Array)
+              elements.each do |element|
+                # Mullions is a special case here, they are extracted as base object with @displayValue from revit..
+                if element['@displayValue'].nil?
+                  obj['geometry'].append(element)
+                else
+                  obj['geometry'] += element['@displayValue']
+                end
               end
             end
           end

--- a/speckle_connector/src/speckle_objects/revit/revit_definition.rb
+++ b/speckle_connector/src/speckle_objects/revit/revit_definition.rb
@@ -15,8 +15,10 @@ module SpeckleConnector
             family = def_obj['family']
             type = def_obj['type']
             category = def_obj['category']
+            element_id = def_obj['elementId']
+            id = def_obj['id']
 
-            return "#{family}-#{type}-#{category}-#{def_obj['elementId']}"
+            return "#{family}-#{type}-#{category}-#{element_id}-#{id}"
           end
 
           def self.to_native(state, definition, layer, entities, &convert_to_native)


### PR DESCRIPTION
`RevitWall` object converting to native after this fix, previously in 2.15 was done with `DisplayValue` object.

Closing #304