### PR TITLE
Fix (Scene): missing views from Revit

### DIFF
--- a/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
+++ b/speckle_connector/src/speckle_objects/speckle/core/models/model_collection.rb
@@ -66,6 +66,13 @@ module SpeckleConnector
 
             def self.to_native(state, model_collection, layer, entities, &convert_to_native)
               elements = model_collection['elements']
+              views = model_collection['@Views']
+              if views
+                views.each do |view|
+                  new_state, _converted_entities = convert_to_native.call(state, view, layer, entities)
+                  state = new_state
+                end
+              end
 
               elements.each do |element|
                 new_state, _converted_entities = convert_to_native.call(state, element, layer, entities)


### PR DESCRIPTION
Previously it was assuming views arrive in elements of collection, but they are outside of layer collections.