### PR TITLE
fix: Use correct digicert context + pass fingerprint to ISS compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,14 +70,13 @@ jobs:
                   cd C:\
                   echo $env:SM_CLIENT_CERT_FILE_B64 > certificate.txt
                   certutil -decode certificate.txt certificate.p12
-                  echo $env:SM_OV_PEM_CERT > SpeckleOVCertificate-2024.pem
             - run:
                 name: "Sync Certs"
                 command: |
                   & $env:SSM\smksp_cert_sync.exe
             - run:
                 name: "Build Installer"
-                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\sketchup.iss /Sbyparam=$p /DSIGN_INSTALLER
+                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\sketchup.iss /Sbyparam=$p /DSIGN_INSTALLER /DCODE_SIGNING_CERT_FINGERPRINT=%SM_CODE_SIGNING_CERT_SHA1_HASH%
                 shell: cmd.exe
       - persist_to_workspace:
           root: ./
@@ -143,8 +142,8 @@ jobs:
       - run:
           name: Copy files to installer
           command: |
-                  mkdir -p speckle-sharp-ci-tools/Mac/<< parameters.installername >>/.installationFiles/
-                  cp << parameters.slug >>-mac.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
+            mkdir -p speckle-sharp-ci-tools/Mac/<< parameters.installername >>/.installationFiles/
+            cp << parameters.slug >>-mac.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
       # Create installer
       - run:
           name: Exit if External PR
@@ -176,7 +175,7 @@ jobs:
                 root: ./
                 paths:
                   - speckle-sharp-ci-tools/Installers
-  
+
   get-ci-tools: # Clones our ci tools and persists them to the workspace
     docker:
       - image: cimg/base:2021.01
@@ -252,7 +251,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-          context: digicert-signing-connectors-test
+          context: digicert-keylocker
 
       - build-connector-mac:
           slug: sketchup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,10 @@ jobs:
                   & $env:SSM\smksp_cert_sync.exe
             - run:
                 name: "Build Installer"
-                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\sketchup.iss /Sbyparam=$p /DSIGN_INSTALLER /DCODE_SIGNING_CERT_FINGERPRINT=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\sketchup.iss \
+                  /Sbyparam=$p \
+                  /DSIGN_INSTALLER \
+                  /DCODE_SIGNING_CERT_FINGERPRINT=%SM_CODE_SIGNING_CERT_SHA1_HASH%
                 shell: cmd.exe
       - persist_to_workspace:
           root: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,7 @@ jobs:
                   & $env:SSM\smksp_cert_sync.exe
             - run:
                 name: "Build Installer"
-                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\sketchup.iss \
-                  /Sbyparam=$p \
-                  /DSIGN_INSTALLER \
-                  /DCODE_SIGNING_CERT_FINGERPRINT=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\sketchup.iss /Sbyparam=$p /DSIGN_INSTALLER /DCODE_SIGNING_CERT_FINGERPRINT=%SM_CODE_SIGNING_CERT_SHA1_HASH%
                 shell: cmd.exe
       - persist_to_workspace:
           root: ./


### PR DESCRIPTION
Adds minor changes to the CI script to align with the latest changes in `speckle-sharp-ci-tools`

- Use `digicert-keylocker` context
- Pass the certificate fingerprint into the ISS compiler