### PR TITLE
chore(domains): update to *.speckle.systems domains

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
 
   build-connector-mac:
     macos:
-      xcode: 12.5.1
+      xcode: 13.4.1
     parameters:
       projname:
         type: string

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ What is Speckle? Check our ![YouTube Video Views](https://img.shields.io/youtube
 
 Give Speckle a try in no time by:
 
-- [![speckle XYZ](https://img.shields.io/badge/https://-speckle.xyz-0069ff?style=flat-square&logo=hackthebox&logoColor=white)](https://speckle.xyz) ⇒ creating an account at our public server
+- [![app.speckle.systems](https://img.shields.io/badge/https://-speckle.xyz-0069ff?style=flat-square&logo=hackthebox&logoColor=white)](https://app.speckle.systems) ⇒ creating an account at our public server
 - [![create a droplet](https://img.shields.io/badge/Create%20a%20Droplet-0069ff?style=flat-square&logo=digitalocean&logoColor=white)](https://marketplace.digitalocean.com/apps/speckle-server?refcode=947a2b5d7dc1) ⇒ deploying an instance in 1 click 
 
 ### Resources

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,3 +1,3 @@
 VUE_APP_DEV_TOKEN=
 VUE_APP_SPECKLE_NAME=SpeckleSketchup
-VUE_APP_DEFAULT_SERVER=https://latest.speckle.dev
+VUE_APP_DEFAULT_SERVER=https://latest.speckle.systems


### PR DESCRIPTION
Part of https://linear.app/speckle/issue/WEB-1337/update-hard-coded-references-to-specklexyz-and-latestspeckledev