### PR TITLE
CXPLA-26 Update CI jobs to pass correct version to deploy step.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,15 @@ on:
       version:
         description: "The computed version number for this run"
         value: ${{ jobs.build.outputs.version }}
-
+      info_version:
+        description: "The assembly info version for this run"
+        value: ${{ jobs.build.outputs.info_version }}
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.set-version.outputs.version }}
+      info_version: ${{ steps.set-info-version.outputs.info-version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -51,3 +54,6 @@ jobs:
       - id: set-version
         name: Set version to output
         run: echo "version=${{steps.gitversion.outputs.semVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?
+      - id: set-info-version
+        name: Set version to output
+        run: echo "info-version=${{steps.gitversion.outputs.AssemblySemVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,16 @@ on:
     outputs:
       semver:
         description: "The computed version number for this run"
-        value: ${{ jobs.build.outputs.version }}
+        value: ${{ jobs.build.outputs.semver }}
       file_version:
         description: "The assembly info version for this run"
-        value: ${{ jobs.build.outputs.info_version }}
+        value: ${{ jobs.build.outputs.file_version }}
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.set-version.outputs.version }}
-      info_version: ${{ steps.set-info-version.outputs.info-version }}
+      semver: ${{ steps.set-version.outputs.semver }}
+      file_version: ${{ steps.set-info-version.outputs.file-version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ on:
   pull_request:
   workflow_call:
     outputs:
-      version:
+      semver:
         description: "The computed version number for this run"
         value: ${{ jobs.build.outputs.version }}
-      info_version:
+      file_version:
         description: "The assembly info version for this run"
         value: ${{ jobs.build.outputs.info_version }}
 jobs:
@@ -53,7 +53,7 @@ jobs:
           compression-level: 0 # no compression
       - id: set-version
         name: Set version to output
-        run: echo "version=${{steps.gitversion.outputs.semVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?
+        run: echo "semver=${{steps.gitversion.outputs.semVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?
       - id: set-info-version
         name: Set version to output
-        run: echo "info-version=${{steps.gitversion.outputs.AssemblySemVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?
+        run: echo "file-version=${{steps.gitversion.outputs.AssemblySemVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: ["dui3/alpha"] # Continuous delivery on every long-lived branch
+    branches: ["dui3/alpha", deploy/*] # Continuous delivery on every long-lived branch
     tags: ["3.*"] # Manual delivery on every 3.x tag
 
 jobs:
@@ -22,8 +22,8 @@ jobs:
           workflow: Build Sketchup
           repo: specklesystems/connector-installers
           token: ${{ secrets.CONNECTORS_GH_TOKEN }}
-          inputs: '{ "run_id": "${{ github.run_id }}", "version": "${{ needs.build.outputs.version }}" }'
-          ref: main
+          inputs: '{ "run_id": "${{ github.run_id }}", "version": "${{ needs.build.outputs.version }}", "info_version": "${{ needs.build.outputs.info_version }}" }'
+          ref: sketchup-installer-fix
           wait-for-completion: true
           wait-for-completion-interval: 10s
           wait-for-completion-timeout: 10m

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: ["dui3/alpha", deploy/*] # Continuous delivery on every long-lived branch
+    branches: ["dui3/alpha"] # Continuous delivery on every long-lived branch
     tags: ["3.*"] # Manual delivery on every 3.x tag
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: ["dui3/alpha"] # Continuous delivery on every long-lived branch
+    branches: ["dui3/alpha", "deploy/*"] # Continuous delivery on every long-lived branch
     tags: ["3.*"] # Manual delivery on every 3.x tag
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           workflow: Build Sketchup
           repo: specklesystems/connector-installers
           token: ${{ secrets.CONNECTORS_GH_TOKEN }}
-          inputs: '{ "run_id": "${{ github.run_id }}", "version": "${{ needs.build.outputs.version }}", "info_version": "${{ needs.build.outputs.info_version }}" }'
+          inputs: '{ "run_id": "${{ github.run_id }}", "semver": "${{ needs.build.outputs.semver }}", "file_version": "${{ needs.build.outputs.file_version }}" }'
           ref: sketchup-installer-fix
           wait-for-completion: true
           wait-for-completion-interval: 10s


### PR DESCRIPTION
> MERGE https://github.com/specklesystems/connector-installers/pull/9 BEFORE THIS!

Previously, the deploy step was using `3.0.0-fake` as it's version.

We now compute the version using `GitVersion` in the same way we do for `speckle-sharp-connectors` repo.

This guarantees consistency between repos and uniqueness in the autogenerated versions.

Tweaks can be made as needed