### PR TITLE
chore(ci): Replace GitVersion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,54 +8,57 @@ on:
   workflow_call:
     outputs:
       semver:
-        description: "The computed version number for this run"
+        description: "The full SemVer 2.0 version of this build, e.g. '3.0.0-alpha.1234' (note: no 'v'-prefix)"
         value: ${{ jobs.build.outputs.semver }}
       file_version:
-        description: "The assembly info version for this run"
+        description: "The file info version, e.g. '3.0.0.1234'"
         value: ${{ jobs.build.outputs.file_version }}
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       semver: ${{ steps.set-version.outputs.semver }}
-      file_version: ${{ steps.set-info-version.outputs.file-version }}
+      file_version: ${{ steps.set-version.outputs.file-version }}
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
 
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.0.0
-        with:
-          versionSpec: 6.0.5 # github actions doesnt like 6.1.0 onwards https://github.com/GitTools/actions/blob/main/docs/versions.md
+      - id: set-version
+        name: Set version to output
+        shell: bash
+        run: |
+          TAG=${{ github.ref_name }}
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            TAG="v3.0.99.${{ github.run_number }}"
+          fi
+          SEMVER="${TAG#v}"
+          FILE_VERSION=$(echo "$TAG" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
 
-      - name: Determine Version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.0.0
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "file-version=$FILE_VERSION" >> "$GITHUB_OUTPUT"
+
+          echo $SEMVER
+          echo $FILE_VERSION
 
       - name: Set connector version
         run: |
-          python patch_version.py ${{steps.gitversion.outputs.semVer}}
+          python patch_version.py ${{steps.set-version.outputs.semver}}
 
       - uses: montudor/action-zip@v1
         with:
           args: zip -q -r sketchup.zip vendor speckle_connector_3/ speckle_connector_3.rb
+          
       - name: ⬆️ Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: output-${{steps.gitversion.outputs.semVer}}
+          name: output-${{steps.set-version.outputs.semver}}
           path: sketchup.zip
           retention-days: 1
           if-no-files-found: error
           compression-level: 0 # no compression
-      - id: set-version
-        name: Set version to output
-        run: echo "semver=${{steps.gitversion.outputs.semVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?
-      - id: set-info-version
-        name: Set version to output
-        run: echo "file-version=${{steps.gitversion.outputs.AssemblySemVer}}" >> "$GITHUB_OUTPUT" # version will be retrieved from tag?


### PR DESCRIPTION
Removes git version, instead the semver is parsed from the tag in the case of public releases, or is parsed from the github build number in the case of non-deploy releases