### PR TITLE
Fix: initializing sketchup connector on large models takes a lot

### DIFF
--- a/speckle_connector_3/src/actions/events/model_event_action.rb
+++ b/speckle_connector_3/src/actions/events/model_event_action.rb
@@ -26,7 +26,8 @@ module SpeckleConnector3
             unless path.nil?
               new_path_entities = path[-1].definition.entities
               new_path_entities.add_observer(observers[ENTITIES_OBSERVER])
-              edges = new_path_entities.grep(Sketchup::Edge)
+              # attach observers to only orphan edges since face edges can be detected via face changes.
+              edges = new_path_entities.grep(Sketchup::Edge).filter { |edge| edge.faces.none? }
               edges.each do |edge|
                 edge.add_observer(observers[ENTITY_OBSERVER])
                 edge.start.add_observer(observers[ENTITY_OBSERVER])

--- a/speckle_connector_3/src/actions/load_sketchup_model.rb
+++ b/speckle_connector_3/src/actions/load_sketchup_model.rb
@@ -27,14 +27,14 @@ module SpeckleConnector3
         new_state = InitializeMaterials.update_state(new_state)
 
         # Read speckle entities
-        new_speckle_entities = SketchupModel::Reader::SpeckleEntitiesReader.read(sketchup_model.entities)
-        new_speckle_state = new_state.speckle_state.with_speckle_entities(Immutable::Hash.new(new_speckle_entities))
+        #new_speckle_entities = SketchupModel::Reader::SpeckleEntitiesReader.read(sketchup_model.entities)
+        #new_speckle_state = new_state.speckle_state.with_speckle_entities(Immutable::Hash.new(new_speckle_entities))
         # POC: Reconsider it when we will do caching between sessions!
-        new_speckle_state = new_speckle_state.with_empty_object_references
+        # new_speckle_state = new_speckle_state.with_empty_object_references
         # Read mapped entities
-        new_mapped_entities = SketchupModel::Reader::MapperReader.read_mapped_entities(sketchup_model.entities)
-        new_speckle_state = new_speckle_state.with_mapped_entities(Immutable::Hash.new(new_mapped_entities))
-        new_state = new_state.with_speckle_state(new_speckle_state)
+        # new_mapped_entities = SketchupModel::Reader::MapperReader.read_mapped_entities(sketchup_model.entities)
+        # new_speckle_state = new_speckle_state.with_mapped_entities(Immutable::Hash.new(new_mapped_entities))
+        # new_state = new_state.with_speckle_state(new_speckle_state)
 
         # Read preferences from database and model.
         preferences = Preferences.read_preferences(new_state.sketchup_state.sketchup_model)


### PR DESCRIPTION
He had legacy entity read functionality that was causing the problem.