### PR TITLE
Fix: try adding object ids to render material proxies

### DIFF
--- a/speckle_connector_3/src/sketchup_model/materials/material_manager.rb
+++ b/speckle_connector_3/src/sketchup_model/materials/material_manager.rb
@@ -34,7 +34,7 @@ module SpeckleConnector3
 
             unless material.nil?
               if render_material_proxies.has_key?(material.persistent_id.to_s)
-                render_material_proxies[material.persistent_id.to_s].add_object_id(entity.persistent_id.to_s)
+                render_material_proxies[material.persistent_id.to_s].try_add_object_id(entity.persistent_id.to_s)
               else
                 convert_material_and_add_to_proxies(material, entity)
               end
@@ -43,7 +43,7 @@ module SpeckleConnector3
             unless back_material.nil?
               if render_material_proxies.has_key?(back_material.persistent_id.to_s)
                 render_material_proxies[back_material.persistent_id.to_s]
-                  .add_object_id("#{entity.persistent_id.to_s}_back")
+                  .try_add_object_id("#{entity.persistent_id.to_s}_back")
               else
                 convert_material_and_add_to_proxies(back_material, entity, true)
               end

--- a/speckle_connector_3/src/speckle_objects/render_material_proxy.rb
+++ b/speckle_connector_3/src/speckle_objects/render_material_proxy.rb
@@ -35,9 +35,11 @@ module SpeckleConnector3
       end
 
       # @param object_id [String] application id of the object to add into proxy list
-      def add_object_id(object_id)
-        object_ids.append(object_id)
-        self[:objects] = object_ids
+      def try_add_object_id(object_id)
+        unless object_ids.include?(object_id)
+          object_ids.append(object_id)
+          self[:objects] = object_ids
+        end
       end
     end
   end


### PR DESCRIPTION
We were repetetively adding object ids to render material proxies if they appear on different instances. I do not know why it lately became a problem. But it is a simple fix.