### PR TITLE
fix(send): reuse the DUI-created ingestion for 4.0 artifact sends (EN…

### DIFF
--- a/speckle_connector_3/src/actions/send_actions/send.rb
+++ b/speckle_connector_3/src/actions/send_actions/send.rb
@@ -21,9 +21,13 @@ module SpeckleConnector3
       USE_ARTIFACT_PIPELINE = true
 
       # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
+      # @param ingestion_id [String, nil] the DUI-created ingestion (4.0 artifact path)
+      # @param version_id [String, nil] the pre-allocated version id of that ingestion
       # @return [States::State] the new updated state object
-      def self.update_state(state, resolve_id, model_card_id)
-        return SendArtifacts.update_state(state, resolve_id, model_card_id) if USE_ARTIFACT_PIPELINE
+      def self.update_state(state, resolve_id, model_card_id, ingestion_id = nil, version_id = nil)
+        if USE_ARTIFACT_PIPELINE
+          return SendArtifacts.update_state(state, resolve_id, model_card_id, ingestion_id, version_id)
+        end
 
         # Set active path always to model to be safe always. Later we can address it
         start_time = Time.now.to_f

--- a/speckle_connector_3/src/actions/send_actions/send_artifacts.rb
+++ b/speckle_connector_3/src/actions/send_actions/send_artifacts.rb
@@ -7,25 +7,31 @@ require_relative '../../operations/send_artifacts'
 
 module SpeckleConnector3
   module Actions
-    # Speckle 4.0 send: create a client-side model ingestion, extract the parquet
-    # artefact bundle from the selected entities (ToSpeckleV3, single pass), and
-    # upload it via the v2 data endpoints — all Ruby-side, no JS round-trip. The
-    # alternative to {Actions::Send} (the JSON serialize + sendBatchViaBrowser path).
+    # Speckle 4.0 send: extract the parquet artefact bundle from the selected
+    # entities (ToSpeckleV3, single pass) and upload it via the v2 data endpoints.
+    # The ingestion is created by the DUI before the send reaches Ruby (its id +
+    # pre-allocated versionId arrive as arguments) — one ingestion per publish,
+    # owned by the DUI. After the upload the SERVER creates the version (for
+    # .dat-less bundles only once its datgen job built the viewer .dat); the DUI
+    # subscribes to the ingestion (via the ingestionId in setModelSendResult) and
+    # shows 'version created' + the View CTA only when the server reports success.
+    # The alternative to {Actions::Send} (JSON serialize + sendBatchViaBrowser).
     class SendArtifacts < Action
       SOURCE_APP_SLUG = 'sketchup'
 
       # When true, Send only EXTRACTS the parquet bundle to a local folder
-      # (~/Documents/speckle-skp-test) and skips ingestion-create + upload — so a
-      # real .skp can be validated through ToSpeckleV3 without a v2 server. Set
-      # true to debug extraction locally; false does the full create -> extract ->
-      # upload -> finalize (the version is created by the v2 /uploads/complete call).
+      # (~/Documents/speckle-skp-test) and skips the upload — so a real .skp can
+      # be validated through ToSpeckleV3 without a v2 server. Set true to debug
+      # extraction locally; false does the full extract -> upload flow.
       EXTRACT_ONLY = false
 
       # @param state [States::State] the current state of the {App::SpeckleConnectorApp}
       # @param resolve_id [String] the JS promise id to resolve
       # @param model_card_id [String] the model card being sent
+      # @param ingestion_id [String, nil] the DUI-created ingestion for this publish
+      # @param version_id [String, nil] the pre-allocated version id of that ingestion
       # @return [States::State] the new updated state object
-      def self.update_state(state, resolve_id, model_card_id)
+      def self.update_state(state, resolve_id, model_card_id, ingestion_id = nil, version_id = nil)
         t_start = Time.now.to_f
         state.sketchup_state.sketchup_model.active_path = nil
         units = Converters::SKETCHUP_UNITS[state.sketchup_state.length_units]
@@ -54,38 +60,46 @@ module SpeckleConnector3
           return state.with_add_queue_js_command('sendArtifacts', "sendBinding.receiveResponse('#{resolve_id}')")
         end
 
+        if ingestion_id.to_s.empty? || version_id.to_s.empty?
+          return send_error(state, resolve_id, model_card_id,
+                            'No ingestion received from the DUI — the 4.0 artefact send requires a DUI/server with ingestion pre-allocation support.')
+        end
+
         account = Accounts.get_account_by_id(model_card.account_id)
         params = {
           server_url: account['serverInfo']['url'],
           project_id: model_card.project_id,
           model_id: model_card.model_id,
           token: account['token'],
-          source_app_slug: SOURCE_APP_SLUG,
-          source_app_version: SpeckleConnector3::CONNECTOR_VERSION
+          ingestion_id: ingestion_id,
+          version_id: version_id
         }
 
         progress(state, model_card_id, 'Extracting + uploading artefacts')
         begin
-          result = Operations::SendArtifacts.send_bundle(entities, units, params,
-                                                         state.user_state.model_preferences)
+          result = Operations::SendArtifacts.upload_bundle(entities, units, params,
+                                                           state.user_state.model_preferences)
         rescue StandardError => e
           puts "Speckle 4.0 artefact send FAILED: #{e.message}\n#{e.backtrace&.first(8)&.join("\n")}"
           return send_error(state, resolve_id, model_card_id, e.message)
         end
-        version_id = result[:version_id]
-        puts "Speckle 4.0 artefact send complete — version #{version_id} (project #{model_card.project_id})"
+        puts "Speckle 4.0 artefact upload done — version #{version_id} (project #{model_card.project_id})"
         puts "Speckle 4.0 TOTAL time: #{(Time.now.to_f - t_start).round(2)}s"
 
-        state = send_result(state, model_card_id, version_id, result[:conversion_results])
+        state = send_result(state, model_card_id, version_id, result[:conversion_results],
+                            result[:ingestion_id])
         resolve_js_script = "sendBinding.receiveResponse('#{resolve_id}')"
         state.with_add_queue_js_command('sendArtifacts', resolve_js_script)
       end
 
-      # Emits the DUI send-complete event that clears the card progress and shows the
-      # created version (no ingestionId -> the legacy/direct path: sets
-      # latestCreatedVersionId + clears progress, no ingestion-status subscription).
-      def self.send_result(state, model_card_id, version_id, conversion_results = [])
+      # Emits the DUI send-complete event. With an ingestionId the DUI subscribes
+      # to the ingestion and shows 'version created' + the View CTA only once the
+      # server reports success (the version does not exist until then — the server
+      # creates it, possibly after its datgen job). Without one (EXTRACT_ONLY
+      # debug path) the DUI shows the result immediately.
+      def self.send_result(state, model_card_id, version_id, conversion_results = [], ingestion_id = nil)
         args = { modelCardId: model_card_id, versionId: version_id, sendConversionResults: conversion_results || [] }
+        args[:ingestionId] = ingestion_id unless ingestion_id.to_s.empty?
         state.with_add_queue_js_command('setModelSendResult', "sendBinding.emit('setModelSendResult', #{args.to_json})")
       end
 

--- a/speckle_connector_3/src/artifacts/artifact_uploader.rb
+++ b/speckle_connector_3/src/artifacts/artifact_uploader.rb
@@ -8,12 +8,15 @@ module SpeckleConnector3
   module Artifacts
     # Uploads an already-built artefact bundle via the Speckle v2 data endpoints —
     # a pure-Ruby mirror of the SDK `ArtifactPipeline.UploadFilesAsync`:
-    # sign -> presigned PUT per file -> complete (which creates the version).
+    # sign -> presigned PUT per file -> complete. The `complete` call is an
+    # upload-finalization signal, NOT version creation: the server creates the
+    # version itself once the artefact set is viewer-consumable (for bundles
+    # without a viewer .dat that happens later, after the server-side datgen job).
+    # Clients learn the version exists via the ingestion status subscription.
     #
     # The bundle is filename-keyed and count-agnostic: the server signs one PUT per
-    # basename under versions/{versionId}/{basename}, and `complete` commits with
-    # the pre-allocated versionId. The ingestion + versionId are created upstream
-    # (the JS DUI3 frontend) and passed in here.
+    # basename under versions/{versionId}/{basename}. The ingestion + versionId are
+    # created upstream (the JS DUI3 frontend) and passed in here.
     class ArtifactUploader
       # Concurrent PUTs per file (IO-bound; presigned URLs are independent, so
       # ordering doesn't matter — mirrors ArtifactDownloader's queue).
@@ -93,6 +96,8 @@ module SpeckleConnector3
         post_json(endpoint('sign'), { files: file_names })
       end
 
+      # Signals "all files uploaded" with the etags for integrity verification.
+      # The server takes it from here (creates the version now, or after datgen).
       def complete(etags, root_id, total_children_count)
         resp = post_json(endpoint('complete'), { etags: etags, rootId: root_id, totalChildrenCount: total_children_count })
         resp.is_a?(Hash) ? resp['versionId'] : nil

--- a/speckle_connector_3/src/operations/send_artifacts.rb
+++ b/speckle_connector_3/src/operations/send_artifacts.rb
@@ -4,44 +4,37 @@ require 'tmpdir'
 require 'fileutils'
 require_relative '../convertors/to_speckle_v3'
 require_relative '../artifacts/artifact_uploader'
-require_relative '../artifacts/model_ingestion_client'
 require_relative '../artifacts/op_stats'
 
 module SpeckleConnector3
   module Operations
-    # Orchestrates a Speckle 4.0 artefact send end-to-end (Ruby-side, no JS):
-    # create a client-side model ingestion (pre-allocates the versionId) -> extract
-    # the parquet bundle from the selected entities (ToSpeckleV3, single pass to disk)
-    # -> upload it via the v2 data endpoints. Mirrors speckle-oda's RevitModelExtractor
-    # finalize tail (Complete -> glob {versionId}.*.parquet -> UploadFilesAsync).
+    # Speckle 4.0 artefact send, Ruby-side half: extract the parquet bundle from
+    # the selected entities (ToSpeckleV3, single pass to disk) and upload it via
+    # the v2 data endpoints (sign -> PUT -> complete). The ingestion is created by
+    # the DUI (which also holds the pre-allocated versionId) BEFORE the send
+    # reaches Ruby — one ingestion per publish, owned by the DUI. Ruby never talks
+    # to the ingestion GraphQL API; `complete` here only signals "upload done" —
+    # the SERVER creates the version (after its datgen job for .dat-less bundles),
+    # and the DUI detects that via the ingestion status subscription.
     module SendArtifacts
       module_function
 
       # @param entities [Array<Sketchup::Entity>] the selected top-level entities
       # @param units [String] speckle model units
       # @param params [Hash] { server_url:, project_id:, model_id:, token:,
-      #   source_app_slug:, source_app_version: }
+      #   ingestion_id:, version_id: } — ingestion_id/version_id come from the
+      #   DUI-created ingestion
       # @param preferences [Hash, nil] model preferences (attribute-send settings)
-      # @return [Hash] { version_id:, conversion_results: } — the committed version
-      #   id + one DUI report row per top-level object
-      def send_bundle(entities, units, params, preferences = nil)
+      # @return [Hash] { version_id:, ingestion_id:, conversion_results: } — the
+      #   pre-allocated version id (the version itself may not exist yet; the DUI
+      #   tracks the ingestion until the server creates it), the ingestion id, and
+      #   one DUI report row per top-level object
+      def upload_bundle(entities, units, params, preferences = nil)
         stats = Artifacts::OpStats.new('send')
-        t0 = Time.now.to_f
-        client = Artifacts::ModelIngestionClient.new(params.fetch(:server_url), params.fetch(:token))
-        ingestion = stats.time(:ingestion_create) do
-          client.create(
-            params.fetch(:project_id), params.fetch(:model_id),
-            params.fetch(:source_app_slug), params.fetch(:source_app_version)
-          )
-        end
-        ingestion_id = ingestion[:id]
-        version_id = ingestion[:version_id]
-        if version_id.nil? || version_id.to_s.empty?
-          raise 'Server did not pre-allocate a versionId on ingestion create (needs the v2 data endpoints).'
-        end
+        ingestion_id = params.fetch(:ingestion_id)
+        version_id = params.fetch(:version_id)
         stats.version_id = version_id
         t1 = Time.now.to_f
-        puts "  [timing] ingestion create: #{(t1 - t0).round(2)}s (ingestion #{ingestion_id}, version #{version_id})"
 
         output_dir = File.join(Dir.tmpdir, 'speckle', 'artifacts', version_id)
         FileUtils.mkdir_p(output_dir)
@@ -62,7 +55,11 @@ module SpeckleConnector3
         t3 = Time.now.to_f
         puts "  [timing] upload + finalize: #{(t3 - t2).round(2)}s (#{bundle.size} files)"
         stats.report
-        { version_id: version_id, conversion_results: extractor.conversion_results }
+        {
+          version_id: version_id,
+          ingestion_id: ingestion_id,
+          conversion_results: extractor.conversion_results
+        }
       end
 
       # Extract-only (no server): runs the single-pass extractor and writes the


### PR DESCRIPTION
…G-9043)

Ruby no longer creates its own ingestion: the DUI creates the single ingestion per publish and passes {ingestionId, versionId} down as send args. Ruby extracts and uploads the bundle against it (sign -> PUT -> complete; complete only signals 'upload done' — the server creates the version, after datgen for .dat-less bundles) and echoes the ingestionId back in setModelSendResult, so the DUI subscribes and shows 'version created' + the View CTA only when the server reports success.

Previously this path created a second ingestion (orphaning the DUI's one until server timeout) and reported the pre-allocated versionId as a created version, showing a View CTA that pointed at a version that did not exist yet.