### PR TITLE
feat(send): definition attributes ride the type tables

### DIFF
--- a/speckle_connector_3/src/artifacts/bundle_reader.rb
+++ b/speckle_connector_3/src/artifacts/bundle_reader.rb
@@ -41,6 +41,7 @@ module SpeckleConnector3
         object_app = eav.call('objects').to_h { |r| [r['object_index'], r['application_id']] }
         paths = eav.call('paths').to_h { |r| [r['path_index'], r['path']] }
         props_by_obj = group_eav(eav.call('eav'), paths)
+        props_by_type = group_eav(read_optional(dir, "#{base}.eav.type_eav.parquet"), paths, key: 'type_index')
         geometries = read_geometries(dir, base)
         default_view = read_default_scene_view(dir, base)
 
@@ -48,7 +49,7 @@ module SpeckleConnector3
           collections: {}, materials: {}, colors: {}, definitions: {}, instances: {},
           node_meta: {}, geometries: geometries, objects: [], material_by_geom: {},
           member_tag_paths: {},
-          default_scene_view: default_view, definition_meta: definition_meta(props_by_obj),
+          default_scene_view: default_view, definition_meta: definition_meta(props_by_obj, props_by_type),
           instance_meta: instance_meta(props_by_obj),
           levels: {}, units: producer_units(props_by_obj),
           produced_by: read_produced_by(env),
@@ -59,21 +60,28 @@ module SpeckleConnector3
         model
       end
 
-      # Definition-level metadata (ENG-8842): an eav row-set keyed by the
-      # definition's source persistent id. Joined back by the DEFINITION node's
-      # dense id (the producer stamps it as `@speckle.definition_k`); bundles from
-      # before that stamp fall back to the name join (unique in SketchUp).
+      # Definition-level metadata (ENG-8842): a type_eav row-set keyed by the
+      # definition's persistent id (its type_key) — a definition is a TYPE, not
+      # an interactable scene object, so it never appears in the objects table.
+      # Bundles from before the type split carried the same row-set in eav as a
+      # pseudo-object; both sources are scanned (legacy first, so type rows win)
+      # and old already-published models keep receiving. Joined back by the
+      # DEFINITION node's dense id (the producer stamps it as
+      # `@speckle.definition_k`); bundles from before that stamp fall back to
+      # the name join (unique in SketchUp).
       # Returns {node_k | name -> {description, dictionaries}}.
-      def definition_meta(props_by_obj)
+      def definition_meta(props_by_obj, props_by_type = {})
         meta = {}
-        props_by_obj.each_value do |props|
-          next unless props['speckle_type'] == DEFINITION_PROXY_TYPE
+        [props_by_obj, props_by_type].each do |source|
+          source.each_value do |props|
+            next unless props['speckle_type'] == DEFINITION_PROXY_TYPE
 
-          entry = { description: props['description'], dictionaries: unflatten_dictionaries(props) }
-          def_k = props['@speckle.definition_k']
-          name = props['name']
-          meta[def_k.to_i] = entry unless def_k.nil?
-          meta[name] = entry unless name.nil? || name.to_s.empty?
+            entry = { description: props['description'], dictionaries: unflatten_dictionaries(props) }
+            def_k = props['@speckle.definition_k']
+            name = props['name']
+            meta[def_k.to_i] = entry unless def_k.nil?
+            meta[name] = entry unless name.nil? || name.to_s.empty?
+          end
         end
         meta
       end
@@ -305,13 +313,20 @@ module SpeckleConnector3
       # description/name crashes the SketchUp setters.
       STRING_PATHS = %w[name description speckle_type units layer].freeze
 
-      def group_eav(rows, paths)
-        by_obj = Hash.new { |h, k| h[k] = {} }
+      def group_eav(rows, paths, key: 'object_index')
+        by_key = Hash.new { |h, k| h[k] = {} }
         rows.each do |row|
           path = paths[row['path_index']]
-          by_obj[row['object_index']][path] = STRING_PATHS.include?(path) ? string_value(row) : eav_value(row)
+          by_key[row[key]][path] = STRING_PATHS.include?(path) ? string_value(row) : eav_value(row)
         end
-        by_obj
+        by_key
+      end
+
+      # Reads an eav table a foreign producer may not ship (e.g. type_eav) —
+      # an absent file is an empty table, not an error.
+      def read_optional(dir, filename)
+        path = File.join(dir, filename)
+        File.exist?(path) ? ParquetSource.read_hashes(path) : []
       end
 
       def eav_value(row)

--- a/speckle_connector_3/src/artifacts/eav_writer.rb
+++ b/speckle_connector_3/src/artifacts/eav_writer.rb
@@ -54,6 +54,7 @@ module SpeckleConnector3
         @object_index = IdInterner.new
         @path_index = IdInterner.new
         @type_index = IdInterner.new
+        @type_rows_written = {}
         @completed = false
       end
 
@@ -76,20 +77,36 @@ module SpeckleConnector3
         end
       end
 
-      # Links an object to its type and writes that type's params ONCE (deduped).
-      # `type_rows` is yielded only on the type's first sight.
-      def add_type(application_id, type_key)
-        is_new, type_index = @type_index.get_or_add(type_key)
-        if is_new
-          @types.add_row(type_index, type_key)
-          yield.each do |row|
-            @type_eav.add_row(
-              type_index, get_or_add_path(row.path),
-              row.value_text, row.value_num, boolean_value(row), row.unit, row.internal_definition_name
-            )
-          end
+      # Interns a type_key to its dense type_index (writes the dictionary row on
+      # first sight). Types are NOT objects: they never touch the objects table.
+      def get_or_add_type(type_key)
+        is_new, idx = @type_index.get_or_add(type_key)
+        @types.add_row(idx, type_key) if is_new
+        idx
+      end
+
+      # Writes a type's property rows ONCE per type_key, independent of interning
+      # order — an `add_object_type` link may have interned the type long before
+      # its rows arrive (objects stream during the entity pass, type properties
+      # post-loop). Later calls for the same type_key are no-ops.
+      def add_type_rows(type_key, rows)
+        type_index = get_or_add_type(type_key)
+        return type_index if @type_rows_written.key?(type_index)
+
+        @type_rows_written[type_index] = true
+        rows.each do |row|
+          @type_eav.add_row(
+            type_index, get_or_add_path(row.path),
+            row.value_text, row.value_num, boolean_value(row), row.unit, row.internal_definition_name
+          )
         end
-        @object_type.add_row(get_or_add_object(application_id), type_index)
+        type_index
+      end
+
+      # Links an object to its type (interning both sides) — the star-schema join
+      # edge consumers walk as objects -> object_type -> type_eav.
+      def add_object_type(application_id, type_key)
+        @object_type.add_row(get_or_add_object(application_id), get_or_add_type(type_key))
       end
 
       def complete

--- a/speckle_connector_3/src/artifacts/objects_artifact_pipeline.rb
+++ b/speckle_connector_3/src/artifacts/objects_artifact_pipeline.rb
@@ -40,10 +40,25 @@ module SpeckleConnector3
       # Flattens an object's property tree into eav, keyed by applicationId.
       # @param properties [Hash] nested property dictionary (geometry excluded)
       # @param root_scalars [Array<Array(String,Object)>] bare top-level labels
-      # @param type_key [String, nil] reserved (SketchUp has no type-parameter split)
-      def add_properties(application_id, properties, root_scalars = [], _type_key = nil)
+      def add_properties(application_id, properties, root_scalars = [])
         rows = EavExtraction.flatten_properties(properties, root_scalars, excluded: @excluded)
         @eav.add_rows(application_id, rows)
+      end
+
+      # Flattens a TYPE's property tree into type_eav, keyed by type_key.
+      # SketchUp's "type" is the component definition: attributes shared by every
+      # placement live here (written once per type_key, later calls no-op), and
+      # the definition never enters the objects table — it is not an interactable
+      # scene object. Returns the dense type_index.
+      def add_type_properties(type_key, properties, root_scalars = [])
+        rows = EavExtraction.flatten_properties(properties, root_scalars, excluded: @excluded)
+        @eav.add_type_rows(type_key, rows)
+      end
+
+      # Links an object to its type in object_type (objects -> object_type ->
+      # type_eav, the standard star-schema join).
+      def add_object_type(application_id, type_key)
+        @eav.add_object_type(application_id, type_key)
       end
 
       # ── geometry namespace ────────────────────────────────────────────

--- a/speckle_connector_3/src/convertors/to_speckle_v3.rb
+++ b/speckle_connector_3/src/convertors/to_speckle_v3.rb
@@ -153,9 +153,14 @@ module SpeckleConnector3
         add_properties(app_id, entity, 'Speckle.Core.Models.Instances.InstanceProxy', entity.name)
 
         proxy = @instance_proxies[app_id]
-        def_k = @pipeline.add_definition(entity.definition.persistent_id.to_s, entity.definition.name)
+        def_id = entity.definition.persistent_id.to_s
+        def_k = @pipeline.add_definition(def_id, entity.definition.name)
         inst_k = @pipeline.add_instance(app_id, def_k, proxy[:transform], proxy[:units])
         @pipeline.display_instance(obj_k, inst_k, 0)
+        # The definition is this object's TYPE: the object_type link lets consumers
+        # reach the definition's attributes (written post-loop in emit_definition)
+        # through the standard star-schema join.
+        @pipeline.add_object_type(app_id, def_id)
         # Instance-painted material (ENG-8849): default-material faces inside the
         # definition inherit it, so it must ride on the INSTANCE node, not the
         # shared geometry (same definition can be painted red and blue per placement).
@@ -197,7 +202,7 @@ module SpeckleConnector3
       def emit_definition(definition_proxy)
         def_id = definition_proxy.definition.persistent_id.to_s
         def_k = @pipeline.add_definition(def_id, definition_proxy[:name])
-        add_definition_properties(def_id, def_k, definition_proxy.definition)
+        add_definition_type(def_id, def_k, definition_proxy.definition)
         ord = 0
         definition_proxy.object_ids.each do |member_id|
           member = @flat[member_id]
@@ -386,17 +391,21 @@ module SpeckleConnector3
       end
 
       # Definition-level metadata (ENG-8842): description + definition attribute
-      # dictionaries ride the eav table keyed by the definition's persistent id.
-      # Dictionaries are re-extracted through the send settings here — NOT taken from
-      # the proxy's copy, which DefinitionManager extracts unfiltered (ENG-8843).
+      # dictionaries ride the TYPE tables (types/type_eav), keyed by the
+      # definition's persistent id as the type_key. Definitions are not
+      # interactable scene objects, so they never enter the objects table —
+      # placements reach these rows through their object_type link. Written once
+      # per definition regardless of placement count. Dictionaries are
+      # re-extracted through the send settings here — NOT taken from the proxy's
+      # copy, which DefinitionManager extracts unfiltered (ENG-8843).
       # `@speckle.definition_k` carries the DEFINITION node's dense id so receive
       # joins back exactly (envelope nodes carry no application id).
-      def add_definition_properties(def_id, def_k, definition)
+      def add_definition_type(def_id, def_k, definition)
         root = [['speckle_type', 'Speckle.Core.Models.Instances.InstanceDefinitionProxy'], ['name', definition.name],
                 ['@speckle.definition_k', def_k]]
         description = definition.description
         root << ['description', description] if description && description != ''
-        @pipeline.add_properties(def_id, entity_dictionaries(definition), root)
+        @pipeline.add_type_properties(def_id, entity_dictionaries(definition), root)
       end
 
       # Nested-instance metadata: attribute dictionaries + name, keyed by the
@@ -411,6 +420,11 @@ module SpeckleConnector3
         root = [['speckle_type', 'Speckle.Core.Models.Instances.InstanceProxy'], ['@speckle.instance_k', inst_k]]
         root << ['name', name] unless name.empty?
         @pipeline.add_properties(app_id, dicts, root)
+        # A nested placement that carries an eav row-set links to its definition
+        # type like a top-level object does; plain placements emit no object row,
+        # so they get no link either (object_type never outgrows objects — their
+        # definition membership is already in the envelope via DEFINES_INSTANCE).
+        @pipeline.add_object_type(app_id, entity.definition.persistent_id.to_s)
       end
 
       # Honours the "Include entity attributes" send settings (ENG-8843) with v2's

--- a/tests/src/artifacts/test_artifacts_pipeline.rb
+++ b/tests/src/artifacts/test_artifacts_pipeline.rb
@@ -155,14 +155,16 @@ module SpeckleConnector3
         end
       end
 
-      # ENG-8842: definition description + dictionaries ride the eav table keyed by
-      # the definition id and come back as definition_meta — joined by the stamped
-      # definition node k, with the name join kept for pre-stamp bundles.
+      # ENG-8842: definition description + dictionaries ride the TYPE tables keyed
+      # by the definition id (its type_key) and come back as definition_meta —
+      # joined by the stamped definition node k, with the name join kept for
+      # pre-stamp bundles. Definitions are types, not scene objects: the objects
+      # table stays empty.
       def test_definition_metadata_round_trips
         Dir.mktmpdir('speckle-artifacts') do |dir|
           base = 'ver1'
           p = ObjectsArtifactPipeline.new(dir, base)
-          p.add_properties(
+          p.add_type_properties(
             'def-42', { 'Classifier' => { 'code' => 'XX-1' } },
             [['speckle_type', BundleReader::DEFINITION_PROXY_TYPE], ['name', 'Teddy'],
              ['description', 'A soft bear'], ['@speckle.definition_k', 3]]
@@ -174,6 +176,65 @@ module SpeckleConnector3
           assert_same(meta['Teddy'], meta[3]) # one entry, both join keys
           assert_equal('A soft bear', meta[3][:description])
           assert_equal({ 'Classifier' => { 'code' => 'XX-1' } }, meta[3][:dictionaries])
+          assert_empty(ParquetSource.read_hashes(File.join(dir, "#{base}.eav.objects.parquet")))
+        end
+      end
+
+      # Pre-type-split bundles carried definition metadata as an eav pseudo-object
+      # row-set — those already-published models must keep resolving.
+      def test_legacy_eav_keyed_definition_metadata_still_resolves
+        Dir.mktmpdir('speckle-artifacts') do |dir|
+          base = 'ver1'
+          p = ObjectsArtifactPipeline.new(dir, base)
+          p.add_properties(
+            'def-42', { 'Classifier' => { 'code' => 'XX-1' } },
+            [['speckle_type', BundleReader::DEFINITION_PROXY_TYPE], ['name', 'Teddy'],
+             ['description', 'A soft bear'], ['@speckle.definition_k', 3]]
+          )
+          p.complete
+
+          meta = BundleReader.read(dir, base)[:definition_meta]
+          assert_equal('A soft bear', meta[3][:description])
+          assert_equal({ 'Classifier' => { 'code' => 'XX-1' } }, meta[3][:dictionaries])
+        end
+      end
+
+      # The full star schema: placements link through object_type to the shared
+      # type_eav row-set, written exactly once however many placements (and
+      # add_type_properties calls) there are — and the link order is free: objects
+      # may link before the type's rows land (entity pass vs post-loop).
+      def test_definition_attributes_ride_type_tables
+        Dir.mktmpdir('speckle-artifacts') do |dir|
+          base = 'ver1'
+          p = ObjectsArtifactPipeline.new(dir, base)
+          root = [['speckle_type', BundleReader::DEFINITION_PROXY_TYPE], ['name', 'Door-A'],
+                  ['@speckle.definition_k', 5]]
+          p.intern_object('inst-201')
+          p.add_object_type('inst-201', 'def-100') # link BEFORE rows exist
+          p.intern_object('inst-202')
+          p.add_object_type('inst-202', 'def-100')
+          p.add_type_properties('def-100', { 'props' => { 'height' => 2100 } }, root)
+          p.add_type_properties('def-100', { 'props' => { 'height' => 2100 } }, root) # no-op
+          p.complete
+
+          read = ->(t) { ParquetSource.read_hashes(File.join(dir, "#{base}.eav.#{t}.parquet")) }
+          assert_equal(%w[inst-201 inst-202], read.call('objects').map { |r| r['application_id'] }.sort)
+
+          types = read.call('types')
+          assert_equal(['def-100'], types.map { |r| r['type_key'] })
+          type_index = types.first['type_index']
+
+          links = read.call('object_type')
+          assert_equal([type_index] * 2, links.map { |r| r['type_index'] })
+          assert_equal(read.call('objects').map { |r| r['object_index'] }.sort,
+                       links.map { |r| r['object_index'] }.sort)
+
+          type_rows = read.call('type_eav')
+          assert_equal(4, type_rows.length, 'type rows must be written exactly once')
+          assert(type_rows.all? { |r| r['type_index'] == type_index })
+
+          meta = BundleReader.read(dir, base)[:definition_meta]
+          assert_equal({ 'props' => { 'height' => 2100.0 } }, meta[5][:dictionaries])
         end
       end
 
@@ -184,7 +245,7 @@ module SpeckleConnector3
         Dir.mktmpdir('speckle-artifacts') do |dir|
           base = 'ver1'
           p = ObjectsArtifactPipeline.new(dir, base)
-          p.add_properties(
+          p.add_type_properties(
             'def-1', {},
             [['speckle_type', BundleReader::DEFINITION_PROXY_TYPE], ['name', '101'],
              ['description', '1000'], ['@speckle.definition_k', 3]]


### PR DESCRIPTION
also fixes [ENG-8948: Web app: SketchUp component definitions appear as phantom objects in the object tree](https://linear.app/speckle/issue/ENG-8948/web-app-sketchup-component-definitions-appear-as-phantom-objects-in)

## What

A component definition is a **type**, not an interactable scene object. Its metadata (name, description, attribute dictionaries, `@speckle.definition_k` stamp) now flattens into `type_eav` keyed by the definition's persistent id, and placements join through `object_type` — the standard `objects → object_type → type_eav` star-schema walk that Revit type parameters already use. Definitions no longer enter the eav `objects` table.

## How

- **EavWriter**: order-independent type primitives — `get_or_add_type`, `add_type_rows` (written exactly once per type_key), `add_object_type` — replacing the unused block-based `add_type`. Order-independence matters because objects link to their type during the entity pass while definition rows land post-loop.
- **ToSpeckleV3**: `emit_instance_object` links each placement to its definition type; `add_definition_properties` → `add_definition_type` writes into the type tables. Nested placements link only when they emit a carrier row, so `object_type` never outgrows `objects`.
- **BundleReader**: `definition_meta` scans `type_eav` (read as optional, foreign bundles keep loading) plus the legacy eav pseudo-object rows — already-published bundles keep receiving. `definition_meta` shape unchanged, so `to_native_v3` needs no changes.

## Tests

- New full star-schema round-trip: 2 placements / 1 definition, link-before-rows ordering, dedup on double registration, empty objects table assertion.
- New legacy-bundle regression test (eav-keyed definition rows still resolve).
- Updated ENG-8842 round-trip + numeric-string tests to the type path.

All 15 artifact tests pass; the two other suite failures pre-exist on clean `big-truck` (v2 serializer).

## Note for downstream consumers

SketchUp bundles now populate `type_eav` — external consumers (Power BI star schema, packfile inspector, server) will see definition rows there, distinguishable by `speckle_type = InstanceDefinitionProxy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)