### PR TITLE
fix(receive): restore advanced attributes as authored strings

### DIFF
--- a/speckle_connector_3/src/artifacts/bundle_reader.rb
+++ b/speckle_connector_3/src/artifacts/bundle_reader.rb
@@ -313,13 +313,23 @@ module SpeckleConnector3
       # description/name crashes the SketchUp setters.
       STRING_PATHS = %w[name description speckle_type units layer].freeze
 
+      # SketchUp's advanced-attribute dictionaries (Price/Size/Url on the
+      # definition, Owner/Status on the instance) are string-typed: the panel
+      # silently ignores non-String values, so a Price authored as "1" must come
+      # back as the authored "1", not the query-typed 1.0.
+      STRING_DICT_PREFIXES = %w[properties.SU_DefinitionSet. properties.SU_InstanceSet.].freeze
+
       def group_eav(rows, paths, key: 'object_index')
         by_key = Hash.new { |h, k| h[k] = {} }
         rows.each do |row|
           path = paths[row['path_index']]
-          by_key[row[key]][path] = STRING_PATHS.include?(path) ? string_value(row) : eav_value(row)
+          by_key[row[key]][path] = string_typed?(path) ? string_value(row) : eav_value(row)
         end
         by_key
+      end
+
+      def string_typed?(path)
+        STRING_PATHS.include?(path) || STRING_DICT_PREFIXES.any? { |prefix| path.to_s.start_with?(prefix) }
       end
 
       # Reads an eav table a foreign producer may not ship (e.g. type_eav) —

--- a/tests/src/artifacts/test_artifacts_pipeline.rb
+++ b/tests/src/artifacts/test_artifacts_pipeline.rb
@@ -263,6 +263,33 @@ module SpeckleConnector3
         end
       end
 
+      # SketchUp's advanced-attribute dictionaries are string-typed — the panel
+      # ignores non-String values. A Price authored as "1" gets query-typed to
+      # value_double 1.0 by the eav inference and must come back as the authored
+      # string "1" (definition set via type_eav, instance set via eav).
+      def test_advanced_attribute_values_round_trip_as_strings
+        Dir.mktmpdir('speckle-artifacts') do |dir|
+          base = 'ver1'
+          p = ObjectsArtifactPipeline.new(dir, base)
+          p.add_type_properties(
+            'def-1', { 'SU_DefinitionSet' => { 'Price' => '1', 'Size' => 'a' } },
+            [['speckle_type', BundleReader::DEFINITION_PROXY_TYPE], ['name', 'Box'], ['@speckle.definition_k', 3]]
+          )
+          p.add_properties(
+            'inst-1', { 'SU_InstanceSet' => { 'Owner' => '42' }, 'MyDict' => { 'count' => '42' } },
+            [['speckle_type', BundleReader::INSTANCE_PROXY_TYPE], ['@speckle.instance_k', 7]]
+          )
+          p.complete
+
+          model = BundleReader.read(dir, base)
+          assert_equal({ 'Price' => '1', 'Size' => 'a' },
+                       model[:definition_meta][3][:dictionaries]['SU_DefinitionSet'])
+          assert_equal({ 'Owner' => '42' }, model[:instance_meta][7][:dictionaries]['SU_InstanceSet'])
+          # non-SU dictionaries keep the query-typed value
+          assert_equal(42.0, model[:instance_meta][7][:dictionaries]['MyDict']['count'])
+        end
+      end
+
       # Nested-instance metadata round-trips via the `@speckle.instance_k` stamp:
       # the eav row-set is keyed by the member's own persistent id and joined back
       # to the INSTANCE node by its dense id.


### PR DESCRIPTION
Follow-up to #453 (the fix commit was pushed after that PR merged, so it needed its own PR).

## What

SketchUp's advanced-attribute dictionaries (`SU_DefinitionSet` Price/Size/Url, `SU_InstanceSet` Owner/Status) are **string-typed** — the Entity Info panel stores whatever the user types as a raw String and silently ignores non-String values on display.

The eav inference query-types a Price authored as `"1"` into `value_double 1.0` (kept for SQL querying), and the reader preferred the typed value on receive — so the received definition showed Price unset while Size/Url/Owner (non-numeric strings) survived.

## How

`BundleReader.group_eav` now reads any path under `properties.SU_DefinitionSet.` / `properties.SU_InstanceSet.` through `value_string` (the authored form) — the same treatment `name`/`description` already get via `STRING_PATHS`. Other dictionaries keep the query-typed value, since coercing everything would corrupt genuinely numeric attributes set via the Ruby API.

## Tests

New round-trip test: Price `"1"` on the definition (type_eav path) and Owner `"42"` on the instance (eav path) come back as authored strings; a non-SU dictionary value stays query-typed. 16 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)