### PR TITLE
fix(send): drop object-level HAS_COLOR; disambiguate HAS_MATERIAL namespaces

### DIFF
--- a/speckle_connector_3/src/artifacts/bundle_reader.rb
+++ b/speckle_connector_3/src/artifacts/bundle_reader.rb
@@ -48,7 +48,7 @@ module SpeckleConnector3
         model = {
           collections: {}, materials: {}, colors: {}, definitions: {}, instances: {},
           node_meta: {}, geometries: geometries, objects: [], material_by_geom: {},
-          member_tag_paths: {},
+          material_by_inst: {}, member_tag_paths: {},
           default_scene_view: default_view, definition_meta: definition_meta(props_by_obj, props_by_type),
           instance_meta: instance_meta(props_by_obj),
           levels: {}, units: producer_units(props_by_obj),
@@ -191,7 +191,17 @@ module SpeckleConnector3
           when RelKind::DISPLAY then obj.call(src)[:displays] << dst
           when RelKind::DISPLAY_INSTANCE then obj.call(src)[:display_instances] << dst
           when RelKind::HAS_COLOR then obj.call(src)[:color_argb] = model[:colors][dst]
-          when RelKind::HAS_MATERIAL then model[:material_by_geom][src] = dst
+          when RelKind::HAS_MATERIAL
+            # src spans TWO id namespaces (spec rel 5: geometry|instance, ENG-8849)
+            # and geometry Ks overlap node Ks numerically — folding both into one
+            # map painted objects with unrelated materials on collision. The
+            # producer stamps `ord` 1 on INSTANCE-sourced edges (placement
+            # painting); pre-stamp bundles fall back to "instance only when the id
+            # can't be a geometry", defaulting ambiguous ids to geometry (a lost
+            # placement paint beats a wrong material appearing).
+            instance_src = r['ord'] == 1 ||
+                           (model[:instances].key?(src) && !model[:geometries].key?(src))
+            (instance_src ? model[:material_by_inst] : model[:material_by_geom])[src] = dst
           when RelKind::DEFINES then model[:definitions][src][:geometry_ks] << dst if model[:definitions][src]
           when RelKind::DEFINES_INSTANCE then model[:definitions][src][:instance_ks] << dst if model[:definitions][src]
           else

--- a/speckle_connector_3/src/artifacts/objects_artifact_pipeline.rb
+++ b/speckle_connector_3/src/artifacts/objects_artifact_pipeline.rb
@@ -145,8 +145,13 @@ module SpeckleConnector3
         @envelope.add_relation(RelKind::DEFINES_INSTANCE, definition_k, instance_k, ord)
       end
 
-      def has_material(geometry_k, material_k)
-        @envelope.add_relation(RelKind::HAS_MATERIAL, geometry_k, material_k, 0)
+      # `src_k` is a geometry K, or an INSTANCE node K for placement painting
+      # (ENG-8849). The two K-spaces overlap numerically and rel 5's src namespace
+      # is their union — undecidable for a reader on collision — so `ord` (unused
+      # by the spec for this rel) carries the producer's discriminator: 1 =
+      # INSTANCE-sourced, 0 = geometry-sourced.
+      def has_material(src_k, material_k, instance: false)
+        @envelope.add_relation(RelKind::HAS_MATERIAL, src_k, material_k, instance ? 1 : 0)
       end
 
       def has_color(src_k, color_k)

--- a/speckle_connector_3/src/convertors/to_native_v3.rb
+++ b/speckle_connector_3/src/convertors/to_native_v3.rb
@@ -452,10 +452,11 @@ module SpeckleConnector3
 
         @stats.add(:instances)
         placed = entities.add_instance(definition, TRANSFORM.to_native(instance[:transform], instance[:units]))
-        # Instance-painted material (ENG-8849): HAS_MATERIAL edges sourced from the
-        # INSTANCE node land in material_by_geom keyed by inst_k; default-material
+        # Instance-painted material (ENG-8849): INSTANCE-sourced HAS_MATERIAL edges
+        # live in their own map — inst_k must never be looked up among geometry Ks
+        # (separate id namespaces that overlap numerically); default-material
         # faces inside the definition then inherit it natively.
-        material = @material_by_k[model[:material_by_geom][inst_k]]
+        material = @material_by_k[model[:material_by_inst][inst_k]]
         placed.material = material if material
         placed
       end

--- a/speckle_connector_3/src/convertors/to_speckle_v3.rb
+++ b/speckle_connector_3/src/convertors/to_speckle_v3.rb
@@ -25,8 +25,10 @@ module SpeckleConnector3
     # not build a Base tree, chunk, hash, or batch.
     #
     # SketchUp's distinguishing axes vs. oda's single-container model: the tag
-    # (layer) folder tree -> nested COLLECTION nodes + IN_COLLECTION, layer colours
-    # -> COLOR nodes + HAS_COLOR, and component instancing -> DEFINITION/INSTANCE.
+    # (layer) folder tree -> nested COLLECTION nodes + IN_COLLECTION (each tag
+    # carries its colour on the CONTAINER node's argb — SketchUp has no object- or
+    # instance-level colour, so no HAS_COLOR edges are emitted), and component
+    # instancing -> DEFINITION/INSTANCE.
     class ToSpeckleV3
       ART = SpeckleConnector3::Artifacts
       SOG = SpeckleConnector3::SpeckleObjects::Geometry
@@ -63,7 +65,6 @@ module SpeckleConnector3
         # the folder-path walk, colour conversion, and render-material conversion
         # run once per layer/material instead of once per entity.
         @collection_k_by_layer = {}
-        @color_int_by_layer = {}
         @material_k_by_material = {}
       end
 
@@ -164,8 +165,7 @@ module SpeckleConnector3
         # Instance-painted material (ENG-8849): default-material faces inside the
         # definition inherit it, so it must ride on the INSTANCE node, not the
         # shared geometry (same definition can be painted red and blue per placement).
-        bind_material(inst_k, entity.material)
-        add_color(obj_k, entity)
+        bind_material(inst_k, entity.material, instance: true)
         @object_count += 1
       end
 
@@ -181,7 +181,6 @@ module SpeckleConnector3
         geom_k = emit_mesh(app_id, [face])
         @pipeline.display(obj_k, geom_k, 0)
         bind_material(geom_k, face.material || face.back_material)
-        add_color(obj_k, face)
         @object_count += 1
       end
 
@@ -194,7 +193,6 @@ module SpeckleConnector3
 
         geom_k = @pipeline.add_geometry(app_id, edge_to_sgeo(edge))
         @pipeline.display(obj_k, geom_k, 0)
-        add_color(obj_k, edge)
         @object_count += 1
       end
 
@@ -222,7 +220,7 @@ module SpeckleConnector3
             nested_def_k = @pipeline.add_definition(member.definition.persistent_id.to_s, member.definition.name)
             inst_k = @pipeline.add_instance(member_id, nested_def_k, proxy[:transform], proxy[:units])
             @pipeline.defines_instance(def_k, inst_k, ord)
-            bind_material(inst_k, member.material)
+            bind_material(inst_k, member.material, instance: true)
             # A tagged nested instance gets an object row + IN_COLLECTION, exactly
             # like a top-level instance (ENG-8851); `force` guarantees the
             # `@speckle.instance_k` eav stamp receive joins the tag back through.
@@ -309,23 +307,16 @@ module SpeckleConnector3
 
       # ── materials / colours / collections / properties ────────────────
 
-      def bind_material(geom_k, material)
+      # `instance: true` marks placement painting (src is an INSTANCE node K, not
+      # a geometry K) — rides the rel's ord as the namespace discriminator.
+      def bind_material(src_k, material, instance: false)
         return if material.nil?
 
         mat_k = @material_k_by_material[material.persistent_id] ||= begin
           rm = SOO::RenderMaterial.from_material(material)
           @pipeline.add_material(material.persistent_id.to_s, rm[:name], rm[:diffuse], rm[:opacity], rm[:metalness], rm[:roughness])
         end
-        @pipeline.has_material(geom_k, mat_k)
-      end
-
-      # Binds the object to its tag (layer) colour — SketchUp's "colour by tag".
-      def add_color(obj_k, entity)
-        layer = entity.layer
-        return if layer.nil?
-
-        argb = @color_int_by_layer[layer.persistent_id] ||= SOO::Color.to_int(layer.color)
-        @pipeline.has_color(obj_k, @pipeline.add_color(argb))
+        @pipeline.has_material(src_k, mat_k, instance: instance)
       end
 
       def in_collection(obj_k, entity)

--- a/tests/src/artifacts/test_artifacts_pipeline.rb
+++ b/tests/src/artifacts/test_artifacts_pipeline.rb
@@ -310,6 +310,59 @@ module SpeckleConnector3
         end
       end
 
+      # HAS_MATERIAL src spans two id namespaces (spec rel 5: geometry|instance,
+      # ENG-8849) that overlap numerically — the reader must route INSTANCE-sourced
+      # edges (placement painting) and geometry-sourced edges into separate maps,
+      # or colliding ids paint objects with unrelated materials.
+      def test_instance_and_geometry_materials_route_to_separate_maps
+        Dir.mktmpdir('speckle-artifacts') do |dir|
+          base = 'ver1'
+          p = ObjectsArtifactPipeline.new(dir, base)
+          def_k = p.add_definition('def-1', 'Box')                     # node 0
+          inst_k = p.add_instance('inst-1', def_k, [1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0], 'm')
+          mat_geo = p.add_material('mat-geo', 'Skin', -2_000_000, 1.0, 0.0, 1.0)
+          mat_inst = p.add_material('mat-inst', 'Paint', -65_536, 1.0, 0.0, 1.0)
+          blob = SgeoEncoder.encode_mesh([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0], [3, 0, 1, 2], 'm')
+          p.add_geometry('mesh-0', blob)
+          geom = p.add_geometry('mesh-1', blob + 'x')                  # geometry 1 == inst_k numerically
+          assert_equal(inst_k, geom, 'test setup: ids must collide')
+          p.has_material(geom, mat_geo)
+          p.has_material(inst_k, mat_inst, instance: true)
+          p.complete
+
+          model = BundleReader.read(dir, base)
+          assert_equal({ geom => mat_geo }, model[:material_by_geom])
+          assert_equal({ inst_k => mat_inst }, model[:material_by_inst])
+        end
+      end
+
+      # Pre-stamp bundles (no ord discriminator): an UNPAINTED instance whose node
+      # id collides with a painted geometry must not steal that material — the
+      # ambiguous id defaults to geometry. An instance-sourced edge whose id
+      # cannot be a geometry is still recovered as placement paint.
+      def test_legacy_material_edges_default_ambiguous_ids_to_geometry
+        Dir.mktmpdir('speckle-artifacts') do |dir|
+          base = 'ver1'
+          p = ObjectsArtifactPipeline.new(dir, base)
+          def_k = p.add_definition('def-1', 'Box')                     # node 0
+          inst_a = p.add_instance('inst-a', def_k, [1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0], 'm') # node 1
+          inst_b = p.add_instance('inst-b', def_k, [1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0], 'm') # node 2
+          mat = p.add_material('mat-skin', 'Skin', -2_000_000, 1.0, 0.0, 1.0)
+          mat_paint = p.add_material('mat-paint', 'Paint', -65_536, 1.0, 0.0, 1.0)
+          blob = SgeoEncoder.encode_mesh([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0], [3, 0, 1, 2], 'm')
+          p.add_geometry('mesh-0', blob)
+          geom = p.add_geometry('mesh-1', blob + 'x')                  # geometry 1 == inst_a
+          p.has_material(geom, mat)                                    # legacy: no stamp
+          p.has_material(inst_b, mat_paint)                            # legacy instance edge, id not a geometry
+          p.complete
+
+          model = BundleReader.read(dir, base)
+          assert_equal({ geom => mat }, model[:material_by_geom], 'ambiguous id stays geometry-scoped')
+          assert_equal({ inst_b => mat_paint }, model[:material_by_inst], 'unambiguous instance edge recovered')
+          refute(model[:material_by_inst].key?(inst_a), 'colliding unpainted instance must not steal the material')
+        end
+      end
+
       # Camera viewpoints round-trip through the frozen bundle-spec `camera_views`
       # schema: one row per view, positions in model units, forward/up unit vectors,
       # perspective/ortho projection scalars mutually exclusive, near/far null.


### PR DESCRIPTION
## What

Two send/receive fixes behind the wrong-colours round trip (unpainted boxes coming back painted):

**1. No more object-level HAS_COLOR.** SketchUp has no object- or instance-level colour. The per-object `HAS_COLOR` edge to the tag colour duplicated what the tag CONTAINER node already carries in `argb` (bundle-spec v5) and wrongly presented objects as colour-overridden. Send no longer emits `HAS_COLOR` at all.

**2. HAS_MATERIAL namespace collision.** Spec rel 5's src spans `geometry|instance` (ENG-8849) — two dense-int K-spaces that overlap numerically, which the spec itself notes must be "disambiguated by the rel's namespaces"… except the union makes that undecidable on collision. Our reader folded both into one map, so an unpainted box whose INSTANCE node id collided with a painted geometry K received that geometry's material (the scale figure's skin/hair on the boxes).

- Producer now stamps `ord = 1` on INSTANCE-sourced edges (`ord` is spec-unused for rel 5, so this is invisible to other readers) — SketchUp bundles are fully self-disambiguating.
- Reader routes the two sources into separate maps (`material_by_geom` / `material_by_inst`); `place_instance` looks up only the instance map.
- Pre-stamp bundles: geometry-first on ambiguous ids (a lost placement paint beats a wrong material appearing); unambiguous instance edges are still recovered.

## Not addressed here

The rel-5 ambiguity is a spec-level gap — the `ord` stamp is a producer-side workaround within the current spec. A dedicated relation id (e.g. `HAS_INSTANCE_MATERIAL`) or formalizing the ord discriminator belongs in speckle-bundle-spec; viewer-side ENG-8849 handling has the same collision exposure.

## Tests

- Colliding geometry K / INSTANCE node id with the ord stamp → both materials route correctly.
- Legacy (pre-stamp) bundle: colliding unpainted instance does NOT steal the geometry's material; unambiguous legacy instance paint still recovered.

18 runs, 135 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)