### PR TITLE
fix(send): publish authored PBR metalness and roughness (ENG-9121)

### DIFF
--- a/speckle_connector_3/src/convertors/to_speckle_v3.rb
+++ b/speckle_connector_3/src/convertors/to_speckle_v3.rb
@@ -314,7 +314,10 @@ module SpeckleConnector3
 
         mat_k = @material_k_by_material[material.persistent_id] ||= begin
           rm = SOO::RenderMaterial.from_material(material)
-          @pipeline.add_material(material.persistent_id.to_s, rm[:name], rm[:diffuse], rm[:opacity], rm[:metalness], rm[:roughness])
+          # Authored PBR values, nil when disabled/unsupported (ENG-9121) — not
+          # v2's fixed metalness 0 / roughness 1.
+          metalness, roughness = SOO::RenderMaterial.pbr_channels(material)
+          @pipeline.add_material(material.persistent_id.to_s, rm[:name], rm[:diffuse], rm[:opacity], metalness, roughness)
         end
         @pipeline.has_material(geom_k, mat_k)
       end

--- a/speckle_connector_3/src/speckle_objects/other/render_material.rb
+++ b/speckle_connector_3/src/speckle_objects/other/render_material.rb
@@ -48,6 +48,20 @@ module SpeckleConnector3
           )
         end
 
+        # Authored PBR channels for the artifact path (ENG-9121): [metalness,
+        # roughness] factors as authored, nil for a disabled channel or a host
+        # without the PBR Material API (SketchUp 2025.0+) — never fabricated
+        # defaults; the bundle MATERIAL columns are nullable. The v2
+        # from_material contract above is unchanged.
+        def self.pbr_channels(material)
+          return [nil, nil] unless material.respond_to?(:metalness_enabled?)
+
+          [
+            material.metalness_enabled? ? material.metallic_factor : nil,
+            material.roughness_enabled? ? material.roughness_factor : nil
+          ]
+        end
+
         # @param state [States::State] state of the application.
         def self.to_native(state, render_material, _layer, _entities, &_convert_to_native)
           return state, [] if render_material.nil?

--- a/tests/src/speckle_objects/test_render_material.rb
+++ b/tests/src/speckle_objects/test_render_material.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+require_relative '../../../speckle_connector_3/src/speckle_objects/other/render_material'
+
+module SpeckleConnector3
+  module SpeckleObjects
+    # Authored PBR channel extraction for the artifact path (ENG-9121) — pure
+    # Ruby, the SketchUp Material API is stubbed by shape (respond_to?-based
+    # capability detection).
+    class RenderMaterialPbrTest < Minitest::Test
+      # SketchUp < 2025: no PBR Material API at all.
+      class LegacyMaterial; end
+
+      # SketchUp 2025.0+ Material with authorable PBR channels.
+      class PbrMaterial
+        def initialize(metalness_enabled:, metallic_factor:, roughness_enabled:, roughness_factor:)
+          @me = metalness_enabled
+          @mf = metallic_factor
+          @re = roughness_enabled
+          @rf = roughness_factor
+        end
+
+        def metalness_enabled?
+          @me
+        end
+
+        def metallic_factor
+          @mf
+        end
+
+        def roughness_enabled?
+          @re
+        end
+
+        def roughness_factor
+          @rf
+        end
+      end
+
+      def test_no_pbr_api_yields_nils
+        assert_equal([nil, nil], Other::RenderMaterial.pbr_channels(LegacyMaterial.new))
+      end
+
+      def test_enabled_channels_publish_authored_factors
+        mat = PbrMaterial.new(metalness_enabled: true, metallic_factor: 0.85,
+                              roughness_enabled: true, roughness_factor: 0.2)
+        assert_equal([0.85, 0.2], Other::RenderMaterial.pbr_channels(mat))
+      end
+
+      def test_disabled_channels_yield_nil_not_defaults
+        mat = PbrMaterial.new(metalness_enabled: false, metallic_factor: 0.85,
+                              roughness_enabled: false, roughness_factor: 0.2)
+        assert_equal([nil, nil], Other::RenderMaterial.pbr_channels(mat))
+      end
+
+      def test_mixed_channels
+        mat = PbrMaterial.new(metalness_enabled: true, metallic_factor: 1.0,
+                              roughness_enabled: false, roughness_factor: 0.4)
+        assert_equal([1.0, nil], Other::RenderMaterial.pbr_channels(mat))
+      end
+
+      def test_v2_from_material_contract_unchanged
+        # The legacy path keeps fixed values — only the artifact path consumes
+        # pbr_channels.
+        assert_respond_to Other::RenderMaterial, :from_material
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes [ENG-9121](https://linear.app/speckle/issue/ENG-9121).

## Problem
The artifact-path material conversion supplied v2's fixed values (`metalness = 0`, `roughness = 1`) regardless of what the material authored — claiming fully-dielectric, fully-rough even when the host couldn't know. The headless `skpextract` path already publishes the authored factors from the same SKP, so connector publishes were strictly less faithful (parity finding X1).

## Change
- New `RenderMaterial.pbr_channels(material)`: reads the authored factors through the SketchUp 2025.0+ Material PBR API (`metalness_enabled?`/`metallic_factor`, `roughness_enabled?`/`roughness_factor`).
- `ToSpeckleV3#bind_material` publishes those values on the MATERIAL node: enabled channels → authored factor; disabled channels or pre-2025 hosts (`respond_to?` capability detection) → **nil** — the bundle MATERIAL columns are nullable, so no fabricated visual defaults, and unsupported hosts publish without exceptions.
- Material identity, name, diffuse, opacity, painted-instance inheritance, and the v2 `from_material` contract are unchanged.

## Parity with skpextract
Enabled channels match exactly (skpextract reads the same factors from the material XML: `enable_metalness`/`metalnessFactor`). Disabled channels: connector publishes nil, skpextract still writes 0/1 defaults — aligning the extractor to nullable is a small follow-up tracked with the ENG-9123 differential work.

## Tests
Pure-Ruby (no SketchUp runtime): capability detection on a PBR-less host, authored factors, disabled→nil (not defaults), mixed channels; nil channels verified through the artifact pipeline's parquet write. Full existing pipeline suite passes (16 runs, 129 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)