### PR TITLE
feat(sgeo): HardEdges flag (bit 11) — soft/hard edges ride the mesh blob

### DIFF
--- a/speckle_connector_3/src/artifacts/sgeo_decoder.rb
+++ b/speckle_connector_3/src/artifacts/sgeo_decoder.rb
@@ -79,7 +79,8 @@ module SpeckleConnector3
         end
         colors = body.byteslice(pos, vcount * 4).unpack('l<*') if (flags & SgeoEncoder::FLAG_HAS_COLORS) != 0
 
-        { type: :mesh, vertices: vertices, faces: faces, units: units, normals: normals, uvs: uvs, colors: colors }
+        { type: :mesh, vertices: vertices, faces: faces, units: units, normals: normals, uvs: uvs, colors: colors,
+          hard_edges: (flags & SgeoEncoder::FLAG_HARD_EDGES) != 0 }
       end
 
       def decode_line(body, units)

--- a/speckle_connector_3/src/artifacts/sgeo_encoder.rb
+++ b/speckle_connector_3/src/artifacts/sgeo_encoder.rb
@@ -33,6 +33,10 @@ module SpeckleConnector3
       FLAG_HAS_NORMALS = 1 << 4
       FLAG_HAS_UVS = 1 << 5
       FLAG_HAS_COLORS = 1 << 6
+      # Set = rebuild with HARD edges; unset = the legacy soften-on-receive default.
+      # Inverted on purpose (spec/sgeo-spec.sql bit 11): every pre-flag bundle has
+      # the bit unset and keeps its current meaning with no version bump.
+      FLAG_HARD_EDGES = 1 << 11
 
       # Units string -> uint16 code (mirrors Units.GetEncodingFromUnit; unknown -> 0).
       UNIT_CODES = {
@@ -54,10 +58,11 @@ module SpeckleConnector3
       # @param uvs [Array<Float>] optional flat uv pairs
       # @param colors [Array<Integer>] optional per-vertex ARGB ints
       # @return [String] the SGEO blob (binary String)
-      def encode_mesh(vertices, faces, units, normals: [], uvs: [], colors: [])
+      def encode_mesh(vertices, faces, units, normals: [], uvs: [], colors: [], hard_edges: false)
         raise ArgumentError, 'Mesh.vertices length must be a multiple of 3.' unless (vertices.length % 3).zero?
 
         flags = 0
+        flags |= FLAG_HARD_EDGES if hard_edges
         flags |= FLAG_HAS_NORMALS unless normals.empty?
         flags |= FLAG_HAS_UVS unless uvs.empty?
         flags |= FLAG_HAS_COLORS unless colors.empty?

--- a/speckle_connector_3/src/convertors/to_native_v3.rb
+++ b/speckle_connector_3/src/convertors/to_native_v3.rb
@@ -600,6 +600,10 @@ module SpeckleConnector3
       # Adds a decoded SGEO geometry (mesh or line) to `entities`. Returns the created
       # entities (faces / edge) so the caller can tag them.
       def add_geometry(entities, geometry, material, is_soften)
+        # SGEO HardEdges (bit 11) is per-geometry and authoritative; the caller's
+        # is_soften (the object-plane @speckle.is_soften eav on transitional
+        # bundles, or the legacy soften default) is the fallback when unset.
+        is_soften = false if geometry[:hard_edges]
         case geometry[:type]
         when :mesh then add_mesh(entities, geometry, material, is_soften)
         when :line then [add_line(entities, geometry)]

--- a/speckle_connector_3/src/convertors/to_speckle_v3.rb
+++ b/speckle_connector_3/src/convertors/to_speckle_v3.rb
@@ -174,8 +174,9 @@ module SpeckleConnector3
         app_id = face.persistent_id.to_s
         obj_k = @pipeline.intern_object(app_id)
         in_collection(obj_k, face)
-        # Carry edge soft/smooth so receive can restore it (eav boolean; the geometry
-        # formats are cross-connector and have no place for host-specific flags).
+        # Edge soft/smooth: the authoritative signal is SGEO HardEdges (bit 11) on
+        # the blob (emit_mesh). This eav row is TRANSITIONAL — old receives read
+        # only @speckle.is_soften; it dies at the stamp cut-over.
         add_properties(app_id, face, 'Objects.Geometry.Mesh', nil, [['@speckle.is_soften', soften?([face])]])
 
         geom_k = emit_mesh(app_id, [face])
@@ -256,7 +257,11 @@ module SpeckleConnector3
       # members), SGEO-encodes, and interns the blob. Returns the geometry K.
       def emit_mesh(mesh_app_id, faces)
         vertices, polygons = faces_to_mesh_arrays(faces)
-        @pipeline.add_geometry(mesh_app_id, ART::SgeoEncoder.encode_mesh(vertices, polygons, @units))
+        # HardEdges (SGEO bit 11) rides the blob — per-geometry and authoritative.
+        # Definition members gain soft/hard fidelity through it too: they never
+        # carried the object-plane @speckle.is_soften eav.
+        blob = ART::SgeoEncoder.encode_mesh(vertices, polygons, @units, hard_edges: !soften?(faces))
+        @pipeline.add_geometry(mesh_app_id, blob)
       end
 
       # Single-loop faces emit one n-gon from their outer loop (v2 parity, ENG-8845 —

--- a/tests/src/artifacts/test_artifacts_pipeline.rb
+++ b/tests/src/artifacts/test_artifacts_pipeline.rb
@@ -4,6 +4,7 @@ require_relative '../../test_helper'
 require 'tmpdir'
 require_relative '../../../speckle_connector_3/src/artifacts/objects_artifact_pipeline'
 require_relative '../../../speckle_connector_3/src/artifacts/sgeo_encoder'
+require_relative '../../../speckle_connector_3/src/artifacts/sgeo_decoder'
 require_relative '../../../speckle_connector_3/src/artifacts/bundle_reader'
 
 module SpeckleConnector3
@@ -26,6 +27,35 @@ module SpeckleConnector3
         assert_equal(3, body[0, 4].unpack1('V'))  # vertex count
         assert_equal(4, body[4, 4].unpack1('V'))  # face stream length
         assert_equal(verts, body[8, 9 * 8].unpack('E*'))
+      end
+
+      def test_sgeo_mesh_hard_edges_flag
+        verts = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+        faces = [3, 0, 1, 2]
+
+        soft = SgeoEncoder.encode_mesh(verts, faces, 'm')
+        hard = SgeoEncoder.encode_mesh(verts, faces, 'm', hard_edges: true)
+
+        # Inverted polarity: default/unset = legacy soften; bit 11 set = hard.
+        assert_equal(0, soft[6, 2].unpack1('v') & SgeoEncoder::FLAG_HARD_EDGES)
+        refute_equal(0, hard[6, 2].unpack1('v') & SgeoEncoder::FLAG_HARD_EDGES)
+
+        decoded_soft = SgeoDecoder.decode(soft)
+        decoded_hard = SgeoDecoder.decode(hard)
+        refute(decoded_soft[:hard_edges])
+        assert(decoded_hard[:hard_edges])
+        # The flag is header-only: bodies stay identical.
+        assert_equal(decoded_soft[:vertices], decoded_hard[:vertices])
+        assert_equal(decoded_soft[:faces], decoded_hard[:faces])
+      end
+
+      def test_sgeo_hard_edges_distinct_blobs_for_identity
+        verts = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+        faces = [3, 0, 1, 2]
+        # Softness lives in the hashed bytes: hard/soft variants of the same mesh
+        # must never collapse to one blob (content-hash identity, ENG-9124 principle).
+        refute_equal(SgeoEncoder.encode_mesh(verts, faces, 'm'),
+                     SgeoEncoder.encode_mesh(verts, faces, 'm', hard_edges: true))
       end
 
       def test_sgeo_line_units


### PR DESCRIPTION
Implements SGEO flag **bit 11 (HardEdges)** per speckle-bundle-spec PR #17 (`spec/sgeo-spec.sql`) for the SketchUp soft/hard edge round-trip.

- **Send**: `encode_mesh` sets bit 11 when `soften?` reports hard edges — at both call sites (top-level faces and definition GroupedMesh members). The `@speckle.is_soften` eav row is still written this release (transitional — old receives reading new bundles would otherwise soften-default and re-blur hard boxes; dies at the stamp cut-over).
- **Receive**: precedence resolved centrally in `add_geometry`: geometry's bit 11 (per-geometry, correct plane) → object's `@speckle.is_soften` eav (transitional bundles) → legacy soften default. **Bonus fix**: definition members gain soft/hard fidelity for the first time — receive previously hardcoded soften for them (they never carried the eav).
- **Polarity is inverted by design**: bit set = hard; unset = legacy soften default, so every existing bundle keeps its current meaning with no format version bump.
- Decoder surfaces `hard_edges:`; unknown bits stay ignored (audited fleet-safe in spec PR #17).

Tests: 22 runs / 158 assertions green (baseline 20/151) — bit round-trip, inverted-polarity default, hard/soft variants produce distinct blob bytes (content-hash identity). Receive-side guard needs an in-app hard-edged-component round-trip on Windows (SketchUp API not unit-testable here).

Follow-ups tracked in spec PR #17: skpextract + other encoders, datgen vendored-decoder sync, sgeo constants codegen, `@speckle.is_soften` retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)