### PR TITLE
feat(send/receive): layer colours ride NODE_HAS_COLOR (rel 29), retiring the argb overload

### DIFF
--- a/speckle_connector_3/src/artifacts/bundle_reader.rb
+++ b/speckle_connector_3/src/artifacts/bundle_reader.rb
@@ -215,6 +215,12 @@ module SpeckleConnector3
           when RelKind::PLACES then places[src] = dst
           when RelKind::DEFINES_MEMBER then member_ords[dst] = [src, r['ord']]
           when RelKind::OBJECT_HAS_MATERIAL then object_material[src] = dst
+          when RelKind::NODE_HAS_COLOR
+            # Rel 29 wins over the argb overloaded onto the CONTAINER row; the row
+            # argb stays untouched as the fallback for pre-rel-29 bundles.
+            if model[:collections][src] && model[:colors].key?(dst)
+              model[:collections][src][:argb] = model[:colors][dst]
+            end
           else
             obj.call(src) if MEMBERSHIP_RELS.include?(rel) # ensure membership-only objects exist
           end

--- a/speckle_connector_3/src/artifacts/envelope_writer.rb
+++ b/speckle_connector_3/src/artifacts/envelope_writer.rb
@@ -49,7 +49,8 @@ module SpeckleConnector3
         [14, 'IN_SYSTEM', 'object', 'node'], [21, 'CONNECTS_TO', 'object', 'object'],
         [23, 'BOUNDS', 'object', 'object'], [24, 'PLACES', 'object', 'node'],
         [25, 'DEFINES_MEMBER', 'node', 'object'], [26, 'OBJECT_HAS_MATERIAL', 'object', 'node'],
-        [27, 'OBJECT_HAS_COLOR', 'object', 'node']
+        [27, 'OBJECT_HAS_COLOR', 'object', 'node'], [28, 'NODE_HAS_MATERIAL', 'node', 'node'],
+        [29, 'NODE_HAS_COLOR', 'node', 'node']
       ].freeze
 
       NODE_KINDS = [

--- a/speckle_connector_3/src/artifacts/objects_artifact_pipeline.rb
+++ b/speckle_connector_3/src/artifacts/objects_artifact_pipeline.rb
@@ -106,10 +106,11 @@ module SpeckleConnector3
       # Since bundle-spec v5 a collection IS a CONTAINER node — `subtype` (its own
       # column, e.g. 'Layer'/'Folder') is the only discriminator. Kept as a separate
       # method from {#add_container} for the 'coll:'-prefixed key namespace.
-      # `argb` is the collection's own colour (a tag's colour), nil when it has none.
-      def add_collection(collection_key, name, parent_collection_k, subtype, argb = nil)
+      # A collection's colour rides {#node_has_color} (rel 29), never the row's argb
+      # (the pre-rel-29 carrier, now read-side fallback only).
+      def add_collection(collection_key, name, parent_collection_k, subtype)
         node('coll:' + collection_key) do |k|
-          @envelope.add_node(k, NodeKind::CONTAINER, name, parent_collection_k, nil, nil, subtype, argb, nil, nil, nil, nil)
+          @envelope.add_node(k, NodeKind::CONTAINER, name, parent_collection_k, nil, nil, subtype, nil, nil, nil, nil, nil)
         end
       end
 
@@ -177,6 +178,14 @@ module SpeckleConnector3
       # placement via PLACES). FILL semantics — geometry-level HAS_MATERIAL wins.
       def object_has_material(object_k, material_k)
         @envelope.add_relation(RelKind::OBJECT_HAS_MATERIAL, object_k, material_k, 0)
+      end
+
+      # Container display colour (rel 29): a tag/layer CONTAINER -> its COLOR node.
+      # The weakest colour tier (object > geometry > container); supersedes the
+      # argb formerly stamped on the CONTAINER row (readers keep that as the
+      # old-bundle fallback; producers no longer write it).
+      def node_has_color(node_k, color_k)
+        @envelope.add_relation(RelKind::NODE_HAS_COLOR, node_k, color_k, 0)
       end
 
       def has_color(src_k, color_k)

--- a/speckle_connector_3/src/artifacts/vocab.rb
+++ b/speckle_connector_3/src/artifacts/vocab.rb
@@ -33,6 +33,9 @@ module SpeckleConnector3
       DEFINES_MEMBER = 25      # DEFINITION -> member object; ord = member ordinal (joins DEFINES on (definition, ord))
       OBJECT_HAS_MATERIAL = 26 # painted object -> MATERIAL node; FILL semantics (geometry-level HAS_MATERIAL wins)
       OBJECT_HAS_COLOR = 27    # object -> COLOR node; FILL semantics (geometry-level HAS_COLOR wins); not emitted by SketchUp
+      # Container appearance (weakest tier of both ladders: object > geometry > container).
+      NODE_HAS_MATERIAL = 28   # CONTAINER -> MATERIAL node (authored layer material); not emitted by SketchUp
+      NODE_HAS_COLOR = 29      # CONTAINER -> COLOR node (tag display colour); supersedes the CONTAINER argb overload
     end
 
     module NodeKind

--- a/speckle_connector_3/src/convertors/to_speckle_v3.rb
+++ b/speckle_connector_3/src/convertors/to_speckle_v3.rb
@@ -25,10 +25,10 @@ module SpeckleConnector3
     # not build a Base tree, chunk, hash, or batch.
     #
     # SketchUp's distinguishing axes vs. oda's single-container model: the tag
-    # (layer) folder tree -> nested COLLECTION nodes + IN_COLLECTION (each tag
-    # carries its colour on the CONTAINER node's argb — SketchUp has no object- or
-    # instance-level colour, so no HAS_COLOR edges are emitted), and component
-    # instancing -> DEFINITION/INSTANCE.
+    # (layer) folder tree -> nested COLLECTION nodes + IN_COLLECTION (each tag's
+    # colour rides a NODE_HAS_COLOR edge to a COLOR node — SketchUp has no
+    # object- or instance-level colour, so no other colour edges are emitted),
+    # and component instancing -> DEFINITION/INSTANCE.
     class ToSpeckleV3
       ART = SpeckleConnector3::Artifacts
       SOG = SpeckleConnector3::SpeckleObjects::Geometry
@@ -394,11 +394,15 @@ module SpeckleConnector3
       end
 
       # subtype 'Folder' for tag folders, 'Layer' for tags — so receive rebuilds each
-      # as the right SketchUp object (LayerFolder vs Layer). Tags carry their colour
-      # on the container node's argb (the cross-connector layer-colour pattern);
-      # folders have no colour in SketchUp.
+      # as the right SketchUp object (LayerFolder vs Layer). A tag's colour rides a
+      # NODE_HAS_COLOR edge (rel 29) to an interned COLOR node; folders have no
+      # colour in SketchUp.
       def ensure_collection(key, name, parent_k, subtype, argb = nil)
-        @collection_ks[key] ||= @pipeline.add_collection(key, name, parent_k, subtype, argb)
+        @collection_ks[key] ||= begin
+          k = @pipeline.add_collection(key, name, parent_k, subtype)
+          @pipeline.node_has_color(k, @pipeline.add_color(argb)) unless argb.nil?
+          k
+        end
       end
 
       def add_properties(app_id, entity, speckle_type, name, extra = [])

--- a/tests/src/artifacts/test_artifacts_pipeline.rb
+++ b/tests/src/artifacts/test_artifacts_pipeline.rb
@@ -169,20 +169,70 @@ module SpeckleConnector3
         end
       end
 
-      # ENG-8841: a tag collection carries its colour on the container node's argb
-      # and it survives the produce->read round trip; folders stay colourless.
-      def test_tag_color_round_trips
+      # ENG-8841 -> rel 29: a tag's colour rides a NODE_HAS_COLOR edge to a COLOR
+      # node and survives the produce->read round trip; folders stay colourless.
+      def test_tag_color_round_trips_via_rel29
         Dir.mktmpdir('speckle-artifacts') do |dir|
           base = 'ver1'
           p = ObjectsArtifactPipeline.new(dir, base)
           folder = p.add_collection('folder-1', 'Site', nil, 'Folder')
-          p.add_collection('tag-1', 'Trees', folder, 'Layer', -65_536)
+          trees = p.add_collection('tag-1', 'Trees', folder, 'Layer')
+          p.node_has_color(trees, p.add_color(-65_536))
           p.complete
 
           colls = BundleReader.read(dir, base)[:collections].values
           assert_equal(-65_536, colls.find { |c| c[:name] == 'Trees' }[:argb])
           assert_nil(colls.find { |c| c[:name] == 'Site' }[:argb])
         end
+      end
+
+      # Rel 29 (NODE_HAS_COLOR) is the SOLE carrier: the CONTAINER row's argb (the
+      # pre-rel-29 overload) is no longer written, and same-coloured tags intern
+      # to one COLOR node.
+      def test_tag_color_rel29_edge_replaces_container_argb
+        Dir.mktmpdir('speckle-artifacts') do |dir|
+          base = 'ver1'
+          p = ObjectsArtifactPipeline.new(dir, base)
+          trees = p.add_collection('tag-1', 'Trees', nil, 'Layer')
+          p.node_has_color(trees, p.add_color(-65_536))
+          shrubs = p.add_collection('tag-2', 'Shrubs', nil, 'Layer')
+          p.node_has_color(shrubs, p.add_color(-65_536))
+          p.complete
+
+          nodes = ParquetSource.read_hashes(File.join(dir, "#{base}.envelope.nodes.parquet"))
+          container = nodes.find { |n| n['kind'] == NodeKind::CONTAINER && n['name'] == 'Trees' }
+          assert_nil(container['argb']) # the argb overload is dead on send
+
+          color_nodes = nodes.select { |n| n['kind'] == NodeKind::COLOR }
+          assert_equal(1, color_nodes.length) # interned: one COLOR node per distinct argb
+          assert_equal(-65_536, color_nodes.first['argb'])
+
+          rels = ParquetSource.read_hashes(File.join(dir, "#{base}.envelope.relations.parquet"))
+          edges = rels.select { |r| r['rel'] == RelKind::NODE_HAS_COLOR }
+          assert_equal(2, edges.length)
+          edge = edges.find { |r| r['src'] == container['id'] }
+          refute_nil(edge)
+          assert_equal(color_nodes.first['id'], edge['dst'])
+        end
+      end
+
+      # Old bundles carried the tag colour as an argb on the CONTAINER row (no rel
+      # 29): the reader still resolves it, and when a bundle carries both (other
+      # producers' transitional output) the rel-29 edge wins over a stale argb.
+      def test_tag_color_container_argb_fallback_and_rel29_precedence
+        nodes = {
+          10 => { 'kind' => NodeKind::CONTAINER, 'name' => 'Trees', 'subtype' => 'Layer', 'argb' => -1 },
+          11 => { 'kind' => NodeKind::CONTAINER, 'name' => 'Shrubs', 'subtype' => 'Layer', 'argb' => -16_711_936 },
+          20 => { 'kind' => NodeKind::COLOR, 'argb' => -65_536 }
+        }
+        model = { collections: {}, materials: {}, colors: {}, definitions: {}, instances: {}, node_meta: {},
+                  geometries: {}, material_by_geom: {}, material_by_inst: {}, member_tag_paths: {},
+                  instance_meta: {} }
+        BundleReader.classify_nodes(nodes, model)
+        BundleReader.wire_relations([{ 'rel' => RelKind::NODE_HAS_COLOR, 'src' => 10, 'dst' => 20 }], model, {}, {}, [])
+
+        assert_equal(-65_536, model[:collections][10][:argb])      # edge wins over the stale argb
+        assert_equal(-16_711_936, model[:collections][11][:argb])  # argb-only (old bundle) unchanged
       end
 
       # ENG-8842: definition description + dictionaries ride the TYPE tables keyed


### PR DESCRIPTION
## What

Adopts bundle-spec rels **28 NODE_HAS_MATERIAL / 29 NODE_HAS_COLOR** (node -> node, container appearance) for SketchUp tag/layer colours, which until now rode as an argb overloaded onto the CONTAINER node row (an undocumented carrier per the spec's rel-29 rationale). Rel 29 is now the **sole carrier on send** — the CONTAINER argb write is retired outright, not dual-written.

Cross-repo context: spec rows in `speckle-bundle-spec/spec/bundle-spec.sql` (rels 28/29), SDK counterpart in speckle-sharp-sdk PR #538.

## Send

- `vocab.rb` gains rel constants 28/29; the vendored slim `rel_types` catalog in `EnvelopeWriter` gains the matching rows (both `node -> node`), mirroring the rel 24-27 additions.
- `ObjectsArtifactPipeline#node_has_color(node_k, color_k)` added beside the rel 24-26 helpers; `add_collection` drops its `argb` param — CONTAINER rows no longer carry a colour.
- `ToSpeckleV3#ensure_collection`: a tag with an authored colour emits a COLOR node (kind 4, interned via the existing `add_color` `col:<argb>` keying, so identical tag colours share one node) and a rel-29 edge from the tag's CONTAINER K to it.
- Rel 28 is catalogued for parity but not emitted — SketchUp tags carry no material.

## Receive

`BundleReader.wire_relations` indexes rel 29 the same way as rels 24-26: the COLOR node's argb overwrites the collection entry's argb. The **read-side** CONTAINER-argb fallback stays for pre-rel-29 bundles (old published models keep their tag colours), and the edge wins over a stale argb when a bundle carries both (other producers' transitional output). `@tag_color_by_path` in `ToNativeV3` is fed from that same collections map, so tag colours resolve with no change there.

## Tests

`tests/src/artifacts/test_artifacts_pipeline.rb`:
- send round trip: coloured tag -> rel-29 edge -> COLOR node -> received collection argb; folders stay colourless.
- send structure: CONTAINER row argb is nil (overload dead on send); two same-coloured tags intern to ONE COLOR node; edges land per container.
- receive: old-bundle fixture (argb-only CONTAINER rows, no rel 29) resolves unchanged; rel-29 wins over a deliberately different stale container argb.

`ruby -Itests tests/src/artifacts/test_artifacts_pipeline.rb`: **24 runs, 166 assertions, 0 failures** (baseline 22/158, all still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)