### PR TITLE
chore(artifacts): pin bundle schema_version to 1 + catalog rows 17/18/22

### DIFF
--- a/speckle_connector_3/src/artifacts/envelope_writer.rb
+++ b/speckle_connector_3/src/artifacts/envelope_writer.rb
@@ -13,7 +13,7 @@ module SpeckleConnector3
     # `speckle-bundle-spec` generated schemas (and the SDK `EnvelopeWriter`);
     # SCHEMA_VERSION must stay in lockstep with `BundleSpec.SchemaVersion`.
     class EnvelopeWriter
-      SCHEMA_VERSION = 5
+      SCHEMA_VERSION = 1
 
       RELATIONS_SCHEMA = [
         { name: 'rel', type: :int32, optional: false },
@@ -46,8 +46,10 @@ module SpeckleConnector3
         [7, 'ON_LEVEL', 'object', 'node'], [8, 'DISPLAY_INSTANCE', 'object', 'node'],
         [9, 'DEFINES_INSTANCE', 'node', 'node'], [10, 'IN_COLLECTION', 'object', 'node'],
         [11, 'IN_MODEL', 'object', 'node'], [12, 'IN_ROOM', 'object', 'object'],
-        [14, 'IN_SYSTEM', 'object', 'node'], [21, 'CONNECTS_TO', 'object', 'object'],
-        [23, 'BOUNDS', 'object', 'object'], [24, 'PLACES', 'object', 'node'],
+        [14, 'IN_SYSTEM', 'object', 'node'], [17, 'IN_GROUP', 'object', 'node'],
+        [18, 'IN_ASSEMBLY', 'object', 'object'], [21, 'CONNECTS_TO', 'object', 'object'],
+        [22, 'HOSTED_ON', 'object', 'object'], [23, 'BOUNDS', 'object', 'object'],
+        [24, 'PLACES', 'object', 'node'],
         [25, 'DEFINES_MEMBER', 'node', 'object'], [26, 'OBJECT_HAS_MATERIAL', 'object', 'node'],
         [27, 'OBJECT_HAS_COLOR', 'object', 'node'], [28, 'NODE_HAS_MATERIAL', 'node', 'node'],
         [29, 'NODE_HAS_COLOR', 'node', 'node']

--- a/speckle_connector_3/src/artifacts/vocab.rb
+++ b/speckle_connector_3/src/artifacts/vocab.rb
@@ -3,11 +3,12 @@
 module SpeckleConnector3
   module Artifacts
     # The fixed envelope relation/node vocabulary + scene-view projection types,
-    # mirroring the `speckle-bundle-spec` catalog (schema_version 5). These integer
-    # codes are a cross-connector contract — never invent new ones here without the
-    # matching spec change + a schema_version bump. Retired ids (rels 13, 15-20, 22;
-    # node kind 6 COLLECTION, folded into CONTAINER + `subtype`) are kept vacant and
-    # never reused; {BundleReader} still accepts them when reading pre-v5 bundles.
+    # mirroring the `speckle-bundle-spec` catalog (schema_version 1, the renumbered
+    # successor of v5). These integer codes are a cross-connector contract — never
+    # invent new ones here without the matching spec change + a schema_version bump.
+    # Retired ids (rels 13, 15, 16, 19, 20; node kind 6 COLLECTION, folded into
+    # CONTAINER + `subtype`) are kept vacant and never reused; {BundleReader} still
+    # accepts them when reading older bundles.
     module RelKind
       DISPLAY = 1
       SOLID = 2 # reserved


### PR DESCRIPTION
SketchUp leg of the schema_version → 1 renumber, after [speckle-bundle-spec#22](https://github.com/specklesystems/speckle-bundle-spec/pull/22), [speckle-sharp-sdk#551](https://github.com/specklesystems/speckle-sharp-sdk/pull/551), [specklepy#513](https://github.com/specklesystems/specklepy/pull/513), [speckle-converters#102](https://github.com/specklesystems/speckle-converters/pull/102).

## Changes
- `EnvelopeWriter::SCHEMA_VERSION` 5 → 1 — the value stamped into `envelope.meta.parquet`.
- `REL_TYPES` catalog: adds **IN_GROUP (17), IN_ASSEMBLY (18), HOSTED_ON (22)**. These are live in the spec catalog but were missing from the rows SketchUp writes to `envelope.rel_types.parquet`, so the emitted catalog had drifted from the spec. SketchUp still never emits these rels — this only makes the self-describing catalog complete.
- `vocab.rb`: retired-id comment corrected (13, 15, 16, 19, 20 — 17/18/22 were un-retired upstream).

SketchUp has no vendored spec / pin file; this is the hand-maintained literal listed under tier C in `speckle-bundle-spec/VERSIONING.md`.

## Verification
- `ruby -c` OK on both files; rubocop offense count unchanged vs `origin/big-truck` (24 pre-existing).
- Rel/node-kind ids and namespaces diffed against `rel_types` / `node_kinds` in `spec/bundle-spec.sql` @ `96c5572` — now identical for live+reserved rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018petCQq4mhdr4dzbqfhLdi
