### PR TITLE
feat(artifacts): schema_version becomes semver VARCHAR "1.0.0" in meta.parquet

### DIFF
--- a/speckle_connector_3/src/artifacts/envelope_writer.rb
+++ b/speckle_connector_3/src/artifacts/envelope_writer.rb
@@ -11,9 +11,10 @@ module SpeckleConnector3
     # `.scene_views.parquet` (producer-authored projections) + optional
     # `.camera_views.parquet` (named camera viewpoints). Mirrors the
     # `speckle-bundle-spec` generated schemas (and the SDK `EnvelopeWriter`);
-    # SCHEMA_VERSION must stay in lockstep with `BundleSpec.SchemaVersion`.
+    # SCHEMA_VERSION is a semver string (VARCHAR in `meta.parquet`, initial
+    # release "1.0.0") and must stay in lockstep with `BundleSpec.SchemaVersion`.
     class EnvelopeWriter
-      SCHEMA_VERSION = 1
+      SCHEMA_VERSION = '1.0.0'
 
       RELATIONS_SCHEMA = [
         { name: 'rel', type: :int32, optional: false },
@@ -104,7 +105,7 @@ module SpeckleConnector3
       def write_catalog
         meta = Parquet::ParquetTableWriter.new(
           path('meta.parquet'),
-          [{ name: 'schema_version', type: :int32, optional: false },
+          [{ name: 'schema_version', type: :string, optional: false },
            { name: 'produced_by', type: :string, optional: true }]
         )
         meta.add_row(SCHEMA_VERSION, 'speckle-sketchup EnvelopeWriter')

--- a/speckle_connector_3/src/artifacts/vocab.rb
+++ b/speckle_connector_3/src/artifacts/vocab.rb
@@ -3,7 +3,7 @@
 module SpeckleConnector3
   module Artifacts
     # The fixed envelope relation/node vocabulary + scene-view projection types,
-    # mirroring the `speckle-bundle-spec` catalog (schema_version 1, the renumbered
+    # mirroring the `speckle-bundle-spec` catalog (schema_version 1.0.0, the renumbered
     # successor of v5). These integer codes are a cross-connector contract — never
     # invent new ones here without the matching spec change + a schema_version bump.
     # Retired ids (rels 13, 15, 16, 19, 20; node kind 6 COLLECTION, folded into

--- a/tests/src/artifacts/test_artifacts_pipeline.rb
+++ b/tests/src/artifacts/test_artifacts_pipeline.rb
@@ -139,7 +139,8 @@ module SpeckleConnector3
           p.complete
 
           meta = ParquetSource.read_hashes(File.join(dir, "#{base}.envelope.meta.parquet"))
-          assert_equal(EnvelopeWriter::SCHEMA_VERSION, meta.first['schema_version'])
+          assert_equal('1.0.0', EnvelopeWriter::SCHEMA_VERSION)
+          assert_equal('1.0.0', meta.first['schema_version'])
 
           nodes = ParquetSource.read_hashes(File.join(dir, "#{base}.envelope.nodes.parquet"))
           containers = nodes.select { |n| n['kind'] == NodeKind::CONTAINER }


### PR DESCRIPTION
Per the bundle-spec decision, `meta.parquet`\s `schema_version` column is now a semver string (VARCHAR) instead of INT32; the initial release is marked `"1.0.0"`.

- `EnvelopeWriter::SCHEMA_VERSION = '1.0.0'`, meta column type `:int32` → `:string`
- comments in `envelope_writer.rb` / `vocab.rb` updated
- test asserts the written meta row equals `"1.0.0"`

Tests: `tests/src/artifacts/test_artifacts_pipeline.rb` — 24 runs, 167 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9rXceTq5Udys9FAgDCRwV