### PR TITLE
ci(deploy): trigger on unprefixed CalVer tags (ENG-9392)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ name: Build and deploy
 on:
   push:
     branches: ["installer-test/**"]
-    tags: ["v202*.*.*"]
+    tags: ["202[0-9].*.*"] # unprefixed CalVer, v-prefix dropped at 2026.9 (ENG-9392)
 
 permissions:
   contents: read


### PR DESCRIPTION
2026.9 drops the v tag prefix stack-wide (ENG-9392). The deploy workflow's tag trigger only matched v-prefixed tags, and the last release tag here is v2026.6.0, so the unprefixed 2026.9.0 tag the release run mints today would not fire the pipeline.

The new glob `202[0-9].*.*` is the pattern already live in speckle-sharp-sdk, and it also matches suffixed tags like 2026.9.0-beta.4.

Pre-.9 hotfix lines are unaffected, because tag pushes run the workflow file at the tagged commit, and old commits keep the old trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfAikwuuMbw7cftiLVUbAb